### PR TITLE
generate release_notes_url

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -124,6 +124,9 @@ func findManifest() (*model.Manifest, error) {
 	}
 	manifest.Version = version
 
+	// Update the release notes url to point at the latest tag.
+	manifest.ReleaseNotesURL = manifest.HomepageURL + "releases/tag/" + BuildTagLatest
+
 	return &manifest, nil
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,6 @@
     "description": "This plugin allows users to coordinate and manage incidents within Mattermost.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-incident-collaboration/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-incident-collaboration/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-incident-collaboration/releases/tag/v1.2.0",
     "icon_path": "assets/incident_plugin_icon.svg",
     "min_server_version": "5.28.0",
     "server": {


### PR DESCRIPTION
#### Summary
The `ReleaseNotesURL` for the most recent `v1.3.1` still points at `v1.2.0`, since this field remains hard-coded. For future versions, update the manifest tooling to generate this too, using the latest tag.

I'm not going to fix v1.3.1, but will just amend the 1.2.0 release notes with a note pointing at v1.3.1 as well.

#### Ticket Link
N/A