### PR TITLE
Use filterOption in ProfileAutocomplete

### DIFF
--- a/webapp/src/components/backstage/profile_autocomplete.tsx
+++ b/webapp/src/components/backstage/profile_autocomplete.tsx
@@ -105,8 +105,7 @@ const ProfileAutocomplete: FC<Props> = (props: Props) => {
 
         //@ts-ignore
         profiles.then(({data}) => {
-            const profilesWithoutAlreadyAdded = data.filter((profile: UserProfile) => !props.userIds.includes(profile.id));
-            callback(profilesWithoutAlreadyAdded);
+            callback(data);
         }).catch(() => {
             // eslint-disable-next-line no-console
             console.error('Error searching user profiles in custom attribute settings dropdown.');
@@ -131,6 +130,7 @@ const ProfileAutocomplete: FC<Props> = (props: Props) => {
             cacheOptions={false}
             defaultOptions={true}
             loadOptions={usersLoader}
+            filterOption={({data}: { data: UserProfile }) => !props.userIds.includes(data.id)}
             onChange={onChange}
             getOptionValue={getOptionValue}
             formatOptionLabel={formatOptionLabel}


### PR DESCRIPTION
#### Summary
React-select has a prop `filterOption` for doing what we were incorrectly doing when grabbing the data from the server. This PR simply moves the filtering logic where it should be.

I found this while working on the new user selector in https://github.com/mattermost/mattermost-plugin-incident-management/pull/440, but I did not want to add more noise there. Hence, this independent PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32313

