### PR TITLE
MM-32452 Allow guest users access to their own incidents.

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -334,6 +334,10 @@ func (h *IncidentHandler) createIncident(newIncident incident.Incident, userID s
 	return h.incidentService.CreateIncident(&newIncident, userID, public)
 }
 
+func (h *IncidentHandler) getRequesterInfo(userID string) (incident.RequesterInfo, error) {
+	return permissions.GetRequesterInfo(userID, h.pluginAPI)
+}
+
 // getIncidents handles the GET /incidents endpoint.
 func (h *IncidentHandler) getIncidents(w http.ResponseWriter, r *http.Request) {
 	filterOptions, err := parseIncidentsFilterOptions(r.URL)
@@ -343,15 +347,17 @@ func (h *IncidentHandler) getIncidents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := r.Header.Get("Mattermost-User-ID")
+	// More detailed permissions checked on DB level.
 	if !permissions.CanViewTeam(userID, filterOptions.TeamID, h.pluginAPI) {
 		HandleErrorWithCode(w, http.StatusForbidden, "permissions error", errors.Errorf(
 			"userID %s does not have view permission for teamID %s", userID, filterOptions.TeamID))
 		return
 	}
 
-	requesterInfo := incident.RequesterInfo{
-		UserID:          userID,
-		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
+	requesterInfo, err := h.getRequesterInfo(userID)
+	if err != nil {
+		HandleError(w, err)
+		return
 	}
 
 	results, err := h.incidentService.GetIncidents(requesterInfo, *filterOptions)
@@ -459,9 +465,10 @@ func (h *IncidentHandler) getCommanders(w http.ResponseWriter, r *http.Request) 
 		TeamID: teamID,
 	}
 
-	requesterInfo := incident.RequesterInfo{
-		UserID:          userID,
-		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
+	requesterInfo, err := h.getRequesterInfo(userID)
+	if err != nil {
+		HandleError(w, err)
+		return
 	}
 
 	commanders, err := h.incidentService.GetCommanders(requesterInfo, options)
@@ -494,9 +501,10 @@ func (h *IncidentHandler) getChannels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requesterInfo := incident.RequesterInfo{
-		UserID:          userID,
-		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
+	requesterInfo, err := h.getRequesterInfo(userID)
+	if err != nil {
+		HandleError(w, err)
+		return
 	}
 
 	incidents, err := h.incidentService.GetIncidents(requesterInfo, *filterOptions)

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -85,7 +85,7 @@ func TestIncidents(t *testing.T) {
 		retI.ChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		poster.EXPECT().PublishWebsocketEventToUser(gomock.Any(), gomock.Any(), gomock.Any())
 		poster.EXPECT().EphemeralPost(gomock.Any(), gomock.Any(), gomock.Any())
 		incidentService.EXPECT().CreateIncident(&i, "testUserID", true).Return(&retI, nil)
@@ -140,7 +140,7 @@ func TestIncidents(t *testing.T) {
 		retI.ChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		poster.EXPECT().PublishWebsocketEventToUser(gomock.Any(), gomock.Any(), gomock.Any())
 		poster.EXPECT().EphemeralPost(gomock.Any(), gomock.Any(), gomock.Any())
 		incidentService.EXPECT().CreateIncident(&i, "testUserID", true).Return(&retI, nil)
@@ -192,7 +192,7 @@ func TestIncidents(t *testing.T) {
 		retI := i
 		retI.ChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(false)
 
 		testrecorder := httptest.NewRecorder()
@@ -254,7 +254,7 @@ func TestIncidents(t *testing.T) {
 		retI := i
 		retI.ChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PRIVATE_CHANNEL).Return(false)
 
 		testrecorder := httptest.NewRecorder()
@@ -353,7 +353,7 @@ func TestIncidents(t *testing.T) {
 			).
 			Times(1)
 
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
@@ -394,7 +394,7 @@ func TestIncidents(t *testing.T) {
 
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		pluginAPI.On("GetPost", "privatePostID").Return(&model.Post{ChannelId: "privateChannelId"}, nil)
 		pluginAPI.On("HasPermissionToChannel", "testUserID", "privateChannelId", model.PERMISSION_READ_CHANNEL).Return(false)
 
@@ -437,7 +437,7 @@ func TestIncidents(t *testing.T) {
 
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		pluginAPI.On("GetPost", "privatePostID").Return(&model.Post{ChannelId: "privateChannelId"}, nil)
 		pluginAPI.On("HasPermissionToChannel", "testUserID", "privateChannelId", model.PERMISSION_READ_CHANNEL).Return(false)
 
@@ -481,7 +481,7 @@ func TestIncidents(t *testing.T) {
 		retI.ChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		incidentService.EXPECT().CreateIncident(&testIncident, "testUserID", true).Return(&retI, nil)
 
 		// Verify that the websocket event is published
@@ -521,7 +521,7 @@ func TestIncidents(t *testing.T) {
 		retI.ChannelID = "channelID"
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		incidentService.EXPECT().CreateIncident(&testIncident, "testUserID", true).Return(&retI, nil)
 
 		// Verify that the websocket event is published
@@ -557,7 +557,7 @@ func TestIncidents(t *testing.T) {
 
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 
 		incidentJSON, err := json.Marshal(testIncident)
 		require.NoError(t, err)
@@ -1186,7 +1186,8 @@ func TestIncidents(t *testing.T) {
 
 		pluginAPI.On("HasPermissionTo", mock.Anything, model.PERMISSION_MANAGE_SYSTEM).Return(false)
 		pluginAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PERMISSION_READ_CHANNEL).Return(true)
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(true)
+		pluginAPI.On("GetUser", "testUserID").Return(&model.User{}, nil)
+		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_VIEW_TEAM).Return(true)
 		result := &incident.GetIncidentsResults{
 			TotalCount: 100,
 			PageCount:  200,
@@ -1220,7 +1221,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("get empty list of incidents", func(t *testing.T) {
 		reset()
 
-		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_LIST_TEAM_CHANNELS).Return(false)
+		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_VIEW_TEAM).Return(false)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("GET", "/api/v0/incidents?team_id=non-existent", nil)

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -230,8 +230,8 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Exclude guest users
-	if isGuest, err := permissions.IsGuest(userID, h.pluginAPI); err != nil {
-		HandleError(w, err)
+	if isGuest, errg := permissions.IsGuest(userID, h.pluginAPI); errg != nil {
+		HandleError(w, errg)
 		return
 	} else if isGuest {
 		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -79,6 +79,19 @@ func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Exclude guest users
+	if isGuest, err := permissions.IsGuest(userID, h.pluginAPI); err != nil {
+		HandleError(w, err)
+		return
+	} else if isGuest {
+		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
+			"userID %s does not have permission to create playbook on teamID %s because they are a guest",
+			userID,
+			pbook.TeamID,
+		))
+		return
+	}
+
 	id, err := h.playbookService.Create(pbook, userID)
 	if err != nil {
 		HandleError(w, err)
@@ -210,6 +223,19 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	if !permissions.CanViewTeam(userID, teamID, h.pluginAPI) {
 		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
 			"userID %s does not have permission to get playbooks on teamID %s",
+			userID,
+			teamID,
+		))
+		return
+	}
+
+	// Exclude guest users
+	if isGuest, err := permissions.IsGuest(userID, h.pluginAPI); err != nil {
+		HandleError(w, err)
+		return
+	} else if isGuest {
+		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
+			"userID %s does not have permission to get playbooks on teamID %s because they are a guest",
 			userID,
 			teamID,
 		))

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -404,9 +404,10 @@ func (r *Runner) actionList() {
 		return
 	}
 
-	requesterInfo := incident.RequesterInfo{
-		UserID:          r.args.UserId,
-		UserIDtoIsAdmin: map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
+	requesterInfo, err := permissions.GetRequesterInfo(r.args.UserId, r.pluginAPI)
+	if err != nil {
+		r.warnUserAndLogErrorf("Error resolving permissions: %v", err)
+		return
 	}
 
 	options := incident.FilterOptions{

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -236,8 +236,9 @@ type DialogState struct {
 // RequesterInfo holds the userID and teamID that this request is regarding, and permissions
 // for the user making the request
 type RequesterInfo struct {
-	UserID          string
-	UserIDtoIsAdmin map[string]bool
+	UserID  string
+	IsAdmin bool
+	IsGuest bool
 }
 
 // ErrNotFound used to indicate entity not found.

--- a/server/sqlstore/incident.go
+++ b/server/sqlstore/incident.go
@@ -557,8 +557,18 @@ func (s *incidentStore) ChangeCreationDate(incidentID string, creationTimestamp 
 }
 
 func (s *incidentStore) buildPermissionsExpr(info incident.RequesterInfo) sq.Sqlizer {
-	if info.UserIDtoIsAdmin[info.UserID] {
+	if info.IsAdmin {
 		return nil
+	}
+
+	// Guests must be channel members
+	if info.IsGuest {
+		return sq.Expr(`
+			  EXISTS(SELECT 1
+						 FROM ChannelMembers as cm
+						 WHERE cm.ChannelId = i.ChannelID
+						   AND cm.UserId = ?)
+		`, info.UserID)
 	}
 
 	// is the requester a channel member, or is the channel public?

--- a/server/sqlstore/incident_test.go
+++ b/server/sqlstore/incident_test.go
@@ -198,8 +198,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options - team1 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID: team1id,
@@ -213,10 +213,44 @@ func TestGetIncidents(t *testing.T) {
 			ExpectedErr: nil,
 		},
 		{
+			Name: "no options - team1 - guest - no channels",
+			RequesterInfo: incident.RequesterInfo{
+				UserID:  lucy.ID,
+				IsGuest: true,
+			},
+			Options: incident.FilterOptions{
+				TeamID: team1id,
+			},
+			Want: incident.GetIncidentsResults{
+				TotalCount: 0,
+				PageCount:  0,
+				HasMore:    false,
+				Items:      []incident.Incident{},
+			},
+			ExpectedErr: nil,
+		},
+		{
+			Name: "no options - team1 - guest - has channels",
+			RequesterInfo: incident.RequesterInfo{
+				UserID:  john.ID,
+				IsGuest: true,
+			},
+			Options: incident.FilterOptions{
+				TeamID: team1id,
+			},
+			Want: incident.GetIncidentsResults{
+				TotalCount: 3,
+				PageCount:  1,
+				HasMore:    false,
+				Items:      []incident.Incident{inc01, inc02, inc03},
+			},
+			ExpectedErr: nil,
+		},
+		{
 			Name: "team1 - desc - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:    team1id,
@@ -233,8 +267,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team2 - sort by CreateAt desc - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:    team2id,
@@ -252,8 +286,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no paging, team3, sort by Name",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID: team3id,
@@ -270,8 +304,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team paged by 1, admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -289,8 +323,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team1 - paged by 3, page 0 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -308,8 +342,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team1 - paged by 3, page 1 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -327,8 +361,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team1 - paged by 3, page 2 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -346,8 +380,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team1 - paged by 3, page 999 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -365,8 +399,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team1 - page 2 by 2 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -384,8 +418,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team1 - page 1 by 2 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -403,8 +437,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "no options, team1 - page 1 by 4 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -422,8 +456,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team1 - only active, page 1 by 2 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:  team1id,
@@ -442,8 +476,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team1 - active, commander3, desc - admin ",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:      team1id,
@@ -462,8 +496,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team1 - search for horse - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:     team1id,
@@ -480,8 +514,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team1 - search for aliens & commander3 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:      team1id,
@@ -499,8 +533,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "fuzzy search using starting characters -- not implemented",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:     team1id,
@@ -517,8 +551,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "fuzzy search using starting characters, active -- not implemented",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:     team1id,
@@ -536,8 +570,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team3 - case-insensitive and unicode characters - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:     team3id,
@@ -554,8 +588,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "bad parameter sort",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID: team2id,
@@ -567,8 +601,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "bad team id",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID: "invalid ID",
@@ -579,8 +613,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "bad parameter direction by",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:    team2id,
@@ -592,8 +626,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "bad commander id",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:      team2id,
@@ -670,8 +704,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team1 - Admin gets incidents with John as member",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:   team1id,
@@ -688,8 +722,8 @@ func TestGetIncidents(t *testing.T) {
 		{
 			Name: "team1 - Admin gets incidents with Jane as member",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID:   team1id,
@@ -1078,8 +1112,8 @@ func TestStressTestGetIncidents(t *testing.T) {
 		t.Run("stress test status posts retrieval", func(t *testing.T) {
 			for _, p := range verifyPages {
 				returned, err := incidentStore.GetIncidents(incident.RequesterInfo{
-					UserID:          "testID",
-					UserIDtoIsAdmin: map[string]bool{"testID": true},
+					UserID:  "testID",
+					IsAdmin: true,
 				}, incident.FilterOptions{
 					TeamID:  teamID,
 					Page:    p,
@@ -1135,8 +1169,8 @@ func TestStressTestGetIncidentsStats(t *testing.T) {
 			for i := 0; i < numReps; i++ {
 				start := time.Now()
 				_, err := incidentStore.GetIncidents(incident.RequesterInfo{
-					UserID:          "testID",
-					UserIDtoIsAdmin: map[string]bool{"testID": true},
+					UserID:  "testID",
+					IsAdmin: true,
 				}, incident.FilterOptions{
 					TeamID:  teamID,
 					Page:    i,
@@ -1378,8 +1412,8 @@ func TestGetCommanders(t *testing.T) {
 		{
 			Name: "team 1 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID: team1id,
@@ -1390,8 +1424,8 @@ func TestGetCommanders(t *testing.T) {
 		{
 			Name: "team 2 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID: team2id,
@@ -1402,8 +1436,8 @@ func TestGetCommanders(t *testing.T) {
 		{
 			Name: "team 3 - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options: incident.FilterOptions{
 				TeamID: team3id,
@@ -1436,8 +1470,8 @@ func TestGetCommanders(t *testing.T) {
 		{
 			Name: "no team - admin",
 			RequesterInfo: incident.RequesterInfo{
-				UserID:          lucy.ID,
-				UserIDtoIsAdmin: map[string]bool{lucy.ID: true},
+				UserID:  lucy.ID,
+				IsAdmin: true,
 			},
 			Options:     incident.FilterOptions{},
 			Expected:    nil,


### PR DESCRIPTION
#### Summary
Guests will now have full access to the incidents they are a member of. They will now not have access to playbooks or the ability to create incidents. 

This is functionality side only. The UI still makes it seem like they can do some of this, but will error (with a message)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32452
