### PR TITLE
Use only one version when naming the build

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -115,7 +115,15 @@ func findManifest() (*model.Manifest, error) {
 	}
 
 	// Update the manifest based on the state of the current commit
-	version := BuildTagCurrent
+	// Use the first version we find (to prevent causing errors)
+	var version string
+	tags := strings.Fields(BuildTagCurrent)
+	for _, t := range tags {
+		if strings.HasPrefix(t, "v") {
+			version = t
+			break
+		}
+	}
 	if version == "" {
 		version = BuildTagLatest + "+" + BuildHashShort
 	}


### PR DESCRIPTION
#### Summary
- There's no way to narrow down the `git tag` command to filter (with a glob or regex) so using the simple rule:
  - If there are multiple tags, we care most about tags that start with `v`, and for simplicity just use the first one we find.

#### Ticket Link
- none