### PR TITLE
MM-32853 & MM-32951 - Hovermenu tweaks and timeline notice

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/rhs/timeline-spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/timeline-spec.js
@@ -243,6 +243,22 @@ describe('timeline', () => {
             removeTimelineEvent('commander_changed', 1, 0, 'Commander changed from @aaron.peterson to @user-1');
         });
     });
+
+    describe('timeline notice', () => {
+        it('shows when there are no events', () => {
+            // * Verify incident created message is visible in the timeline
+            verifyTimelineEvent('incident_created', 1, 0, 'Incident Reported by user-1');
+
+            // * Delete the incident created event
+            removeTimelineEvent('incident_created', 1, 0, 'Incident Reported by user-1');
+
+            // * Verify notice is shown
+            cy.get('#rhsContainer').within(() => {
+                cy.findByText('Timeline events are displayed here as they occur. Hover over an event to remove it.')
+                    .should('exist');
+            });
+        });
+    });
 });
 
 const verifyTimelineEvent = (expectedEventType, expectedNumberOfEvents, expectedEventIndex, expectedEventSummary) => {

--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -48,17 +48,6 @@ const HoverableIcon = styled.i`
     }
 `;
 
-const InfoIcon = styled(HoverableIcon)`
-    position: relative;
-    top: 2px;
-`;
-
-const CloseIcon = styled(HoverableIcon)`
-    position: absolute;
-    right: 13px;
-    top: 13px;
-`;
-
 const StyledPopover = styled(Popover)<PopoverProps>`
     min-width: 180px;
     border-radius: 8px;
@@ -310,9 +299,9 @@ const StepDescription = (props: StepDescriptionProps) : React.ReactElement<StepD
 
     return (
         <>
-            <InfoIcon
+            <HoverMenuButton
                 tabIndex={0}
-                className={'icon icon-information-outline'}
+                className={'icon-information-outline icon-16 btn-icon'}
                 ref={target}
                 onClick={() => setShowTooltip(!showTooltip)}
             />
@@ -325,10 +314,6 @@ const StepDescription = (props: StepDescriptionProps) : React.ReactElement<StepD
                     <div
                         ref={popoverRef}
                     >
-                        <CloseIcon
-                            className={'icon icon-close'}
-                            onClick={() => setShowTooltip(false)}
-                        />
                         <DescriptionTitle>{'Step Description'}</DescriptionTitle>
                         <Scrollbars
                             autoHeight={true}
@@ -427,6 +412,13 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
             <CheckboxContainerLive>
                 {showMenu &&
                     <HoverMenu>
+                        {props.checklistItem.description !== '' &&
+                        <StepDescription
+                            text={props.checklistItem.description}
+                            channelNames={channelNamesMap}
+                            team={team}
+                        />
+                        }
                         <HoverMenuButton
                             className={'icon-trash-can-outline icon-16 btn-icon'}
                             onClick={() => {
@@ -468,13 +460,6 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                         onClick={((e) => handleFormattedTextClick(e, relativeTeamUrl))}
                     >
                         {messageHtmlToComponent(formatText(title, markdownOptions), true, {})}
-                        {props.checklistItem.description !== '' &&
-                            <StepDescription
-                                text={props.checklistItem.description}
-                                channelNames={channelNamesMap}
-                                team={team}
-                            />
-                        }
                     </div>
                 </label>
             </CheckboxContainerLive>

--- a/webapp/src/components/rhs/rhs_shared.tsx
+++ b/webapp/src/components/rhs/rhs_shared.tsx
@@ -103,7 +103,7 @@ export const HoverMenu = styled.div`
     padding: 4px;
     position: absolute;
     right: 0;
-    top: -8px;
+    top: -38px;
     box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.08);
     background-color: var(--center-channel-bg);
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);

--- a/webapp/src/components/rhs/rhs_shared.tsx
+++ b/webapp/src/components/rhs/rhs_shared.tsx
@@ -103,7 +103,7 @@ export const HoverMenu = styled.div`
     padding: 4px;
     position: absolute;
     right: 0;
-    top: -35px;
+    top: -8px;
     box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.08);
     background-color: var(--center-channel-bg);
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
@@ -112,6 +112,8 @@ export const HoverMenu = styled.div`
 `;
 
 export const HoverMenuButton = styled.i`
+    display: inline-block;
     width: 28px;
     height: 28px;
+    padding: 2px 0 0 2px;
 `;

--- a/webapp/src/components/rhs/rhs_shared.tsx
+++ b/webapp/src/components/rhs/rhs_shared.tsx
@@ -103,7 +103,7 @@ export const HoverMenu = styled.div`
     padding: 4px;
     position: absolute;
     right: 0;
-    top: -38px;
+    top: -35px;
     box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.08);
     background-color: var(--center-channel-bg);
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.08);

--- a/webapp/src/components/rhs/rhs_timeline.tsx
+++ b/webapp/src/components/rhs/rhs_timeline.tsx
@@ -29,7 +29,7 @@ import {
 import {ChannelNamesMap} from 'src/types/backstage';
 
 const Timeline = styled.ul`
-    margin: 10px 0 150px 0;
+    margin: 35px 0 150px 0;
     padding: 0;
     list-style: none;
     position: relative;
@@ -43,6 +43,12 @@ const Timeline = styled.ul`
         width: 1px;
         background: #EFF1F5;
     }
+`;
+
+const NoEventsNotice = styled.div`
+    margin: 35px 20px 0 20px;
+    font-size: 14px;
+    font-weight: 600;
 `;
 
 type IdToUserFn = (userId: string) => UserProfile;
@@ -60,7 +66,6 @@ const RHSTimeline = (props: Props) => {
     const getUserFn = (userId: string) => getUserAction(userId)(dispatch as DispatchFunc, getStateFn);
     const selectUser = useSelector<GlobalState, IdToUserFn>((state) => (userId: string) => getUser(state, userId));
     const [events, setEvents] = useState<TimelineEvent[]>([]);
-    const [reportedAt, setReportedAt] = useState(moment());
 
     const ignoredEvent = (e: TimelineEvent) => {
         switch (e.event_type) {
@@ -74,10 +79,6 @@ const RHSTimeline = (props: Props) => {
 
     useEffect(() => {
         Promise.all(props.incident.timeline_events.map(async (e) => {
-            if (e.event_type === TimelineEventType.IncidentCreated) {
-                setReportedAt(moment(e.event_at));
-            }
-
             if (ignoredEvent(e)) {
                 return null;
             }
@@ -101,6 +102,14 @@ const RHSTimeline = (props: Props) => {
         });
     }, [props.incident.timeline_events, displayPreference]);
 
+    if (props.incident.timeline_events.length === 0) {
+        return (
+            <NoEventsNotice>
+                {'Timeline events are displayed here as they occur. Hover over an event to remove it.'}
+            </NoEventsNotice>
+        );
+    }
+
     return (
         <Scrollbars
             autoHide={true}
@@ -117,7 +126,7 @@ const RHSTimeline = (props: Props) => {
                         <RHSTimelineEventItem
                             key={event.id}
                             event={event}
-                            reportedAt={reportedAt}
+                            reportedAt={moment(props.incident.create_at)}
                             channelNames={channelNamesMap}
                             team={team}
                         />


### PR DESCRIPTION
#### Summary
- Moving the hovermenu up a bit so it doesn't hide the `details` icon. This makes it a tad more difficult to click, but it's consistent with how hovermenus work in UIs in general. Please try it out (it's tough to describe the interaction in photos).
- The Incident Timeline notice shows when there are no events (either because the incident had activity before v1.4.0, or because the events were removed). 
- The timeline was using the `reported` event to figure out when the event time starts, but if that's manually removed it wouldn't exist. So using the incident `create_at` field instead (should have used that from the start anyway). I can't think of why that wouldn't be the `reported at` time, can anyone else think of why that would cause a problem?
- e2e tests are broken, probably because cloud branch is broken (community reverted yesterday). Hopefully will be fixed soon.

Looks like:
![image](https://user-images.githubusercontent.com/1490756/108538753-245e4a80-72ad-11eb-9f1c-d8a357ab770b.png)
![image](https://user-images.githubusercontent.com/1490756/108538868-435cdc80-72ad-11eb-820e-f5f1411d323e.png)
![image](https://user-images.githubusercontent.com/1490756/108538880-49eb5400-72ad-11eb-9b89-f56aefac7617.png)
![image](https://user-images.githubusercontent.com/1490756/108538901-540d5280-72ad-11eb-8571-e83ceb7a03a8.png)

#### Ticket Link
- Fixes: https://mattermost.atlassian.net/browse/MM-32853
- https://mattermost.atlassian.net/browse/MM-32951
