### PR TITLE
Fix height of checklist item containers

### DIFF
--- a/webapp/src/components/checklist_item.tsx
+++ b/webapp/src/components/checklist_item.tsx
@@ -199,10 +199,6 @@ const CheckboxContainer = styled.div`
     }
 `;
 
-const CheckboxContainerLive = styled(CheckboxContainer)`
-    height: 35px;
-`;
-
 const CloseContainer = styled.span`
     cursor: pointer;
     opacity: 0;
@@ -409,7 +405,7 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
             onMouseLeave={() => setShowMenu(false)}
             data-testid='checkbox-item-container'
         >
-            <CheckboxContainerLive>
+            <CheckboxContainer>
                 {showMenu &&
                     <HoverMenu>
                         {props.checklistItem.description !== '' &&
@@ -462,7 +458,7 @@ export const ChecklistItemDetails = (props: ChecklistItemDetailsProps): React.Re
                         {messageHtmlToComponent(formatText(title, markdownOptions), true, {})}
                     </div>
                 </label>
-            </CheckboxContainerLive>
+            </CheckboxContainer>
             <ExtrasRow>
                 {props.checklistItem.assignee_id &&
                 <SmallProfile


### PR DESCRIPTION
#### Summary
This PR fixes the height of the checklist item containers. I simply removed the `ChecklistItemContainerLive` component, replacing its only usage with `ChecklistItemContainer` (which was not used anywhere else that was not dead code, actually).

| Before 	| After 	|
|-	|-	|
| ![image](https://user-images.githubusercontent.com/3924815/109290940-95ab7980-7828-11eb-89f5-92b5bc681a51.png) 	| ![image](https://user-images.githubusercontent.com/3924815/109290989-a65bef80-7828-11eb-9756-90587a838900.png) 	|


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33301
