### PR TITLE
MM-32113: Fix banner width

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_details/export_link.tsx
+++ b/webapp/src/components/backstage/incidents/incident_details/export_link.tsx
@@ -12,6 +12,7 @@ import {OVERLAY_DELAY} from 'src/constants';
 
 import {isExportLicensed} from 'src/selectors';
 import {exportChannelUrl} from 'src/client';
+import {Banner} from 'src/components/backstage/shared';
 
 import {Incident} from 'src/types/incident';
 
@@ -36,12 +37,10 @@ const ExportLink: FC<ExportLinkProps> = (props: ExportLinkProps) => {
     };
 
     const downloadStartedBanner = showBanner && (
-        <div className='banner'>
-            <div className='banner__text'>
-                <i className='icon icon-download-outline mr-1'/>
-                {'Downloading channel log'}
-            </div>
-        </div>
+        <Banner>
+            <i className='icon icon-download-outline mr-1'/>
+            {'Downloading channel log'}
+        </Banner>
     );
 
     const linkText = (

--- a/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
+++ b/webapp/src/components/backstage/incidents/incident_details/incident_details.tsx
@@ -219,19 +219,6 @@ const BackstageIncidentDetailsContainer = styled.div`
         text-align: center;
         width: 100%;
     }
-
-    .banner {
-        color: #155724;
-        background-color: #d4edda;
-        border-color: #c3e6cb;
-        position: fixed;
-        top: 0;
-        width: calc(100% - 32rem);
-        z-index: 8;
-        overflow: hidden;
-        padding: 0.5rem 2.4rem;
-        text-align: center;
-    }
 `;
 
 const FetchingStateType = {

--- a/webapp/src/components/backstage/playbook.scss
+++ b/webapp/src/components/backstage/playbook.scss
@@ -88,17 +88,4 @@ $announcement-bar-height: 32px;
             margin-left: -13px;
         }
     }
-
-    .banner {
-        color: #155724;
-        background-color: #d4edda;
-        border-color: #c3e6cb;
-        position: fixed;
-        top: 0;
-        width: calc(100% - 32rem);
-        z-index: 8;
-        overflow: hidden;
-        padding: 1rem 2.4rem;
-        text-align: center;
-    }
 }

--- a/webapp/src/components/backstage/playbook_list.tsx
+++ b/webapp/src/components/backstage/playbook_list.tsx
@@ -28,6 +28,7 @@ import DotMenu, {DropdownMenuItem} from 'src/components/dot_menu';
 import {SortableColHeader} from 'src/components/sortable_col_header';
 import {PaginationRow} from 'src/components/pagination_row';
 import {TEMPLATE_TITLE_KEY, BACKSTAGE_LIST_PER_PAGE} from 'src/constants';
+import {Banner} from 'src/components/backstage/shared';
 
 import RightDots from 'src/components/assets/right_dots';
 import RightFade from 'src/components/assets/right_fade';
@@ -45,7 +46,7 @@ const PlaybookList: FC = () => {
 
     const currentTeam = useSelector<GlobalState, Team>(getCurrentTeam);
 
-    const [fetchParams, setFetchParams] = useState<{sort: string, direction: string, page: number, per_page: number}>(
+    const [fetchParams, setFetchParams] = useState<{ sort: string, direction: string, page: number, per_page: number }>(
         {
             sort: 'title',
             direction: 'asc',
@@ -83,7 +84,7 @@ const PlaybookList: FC = () => {
         navigateToTeamPluginUrl(currentTeam.name, `/playbooks/${playbook.id}`);
     };
 
-    const newPlaybook = (templateTitle?: string|undefined) => {
+    const newPlaybook = (templateTitle?: string | undefined) => {
         const queryParams = qs.stringify({[TEMPLATE_TITLE_KEY]: templateTitle}, {addQueryPrefix: true});
         navigateToTeamPluginUrl(currentTeam.name, `/playbooks/new${queryParams}`);
     };
@@ -122,12 +123,10 @@ const PlaybookList: FC = () => {
     };
 
     const deleteSuccessfulBanner = showBanner && (
-        <div className='banner'>
-            <div className='banner__text'>
-                <i className='icon icon-check mr-1'/>
-                {`The playbook ${selectedPlaybook?.title} was successfully deleted.`}
-            </div>
-        </div>
+        <Banner>
+            <i className='icon icon-check mr-1'/>
+            {`The playbook ${selectedPlaybook?.title} was successfully deleted.`}
+        </Banner>
     );
 
     let body;
@@ -184,7 +183,7 @@ const PlaybookList: FC = () => {
 
     return (
         <div className='Playbook'>
-            { deleteSuccessfulBanner }
+            {deleteSuccessfulBanner}
             <TemplateSelector
                 onSelect={(template: PresetTemplate) => {
                     newPlaybook(template.title);
@@ -332,7 +331,7 @@ const Button = styled.button`
     }
 `;
 
-const NoContentPage = (props: {onNewPlaybook: () => void}) => {
+const NoContentPage = (props: { onNewPlaybook: () => void }) => {
     return (
         <Container>
             <Title>{'What is a Playbook?'}</Title>

--- a/webapp/src/components/backstage/shared.tsx
+++ b/webapp/src/components/backstage/shared.tsx
@@ -4,9 +4,8 @@
 import styled from 'styled-components';
 
 export const Banner = styled.div`
-    color: #155724;
-    background-color: #d4edda;
-    border-color: #c3e6cb;
+    color: var(--button-color);
+    background-color: var(--button-bg);
     position: fixed;
     top: 0;
     left: 0;

--- a/webapp/src/components/backstage/shared.tsx
+++ b/webapp/src/components/backstage/shared.tsx
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import styled from 'styled-components';
+
+export const Banner = styled.div`
+        color: #155724;
+        background-color: #d4edda;
+        border-color: #c3e6cb;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        z-index: 8;
+        overflow: hidden;
+        padding: 1rem 2.4rem;
+        text-align: center;
+`;

--- a/webapp/src/components/backstage/shared.tsx
+++ b/webapp/src/components/backstage/shared.tsx
@@ -4,15 +4,15 @@
 import styled from 'styled-components';
 
 export const Banner = styled.div`
-        color: #155724;
-        background-color: #d4edda;
-        border-color: #c3e6cb;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        z-index: 8;
-        overflow: hidden;
-        padding: 1rem 2.4rem;
-        text-align: center;
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 8;
+    overflow: hidden;
+    padding: 1rem 2.4rem;
+    text-align: center;
 `;


### PR DESCRIPTION
#### Summary
The styling of the banner dates back to when we had a left hand side bar in the backstage (https://github.com/mattermost/mattermost-plugin-incident-collaboration/pull/70/)!

This PR moves the old CSS to a shared style component and updates its width to simply `100%`. I also had to add a `left: 0` so the banner for the exported channel in the incident details view is correctly placed. The `banner__text` class was not defined anywhere, so I ignored it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32113
