### PR TITLE
MM-33439: Fetch invited users independently

### DIFF
--- a/webapp/src/components/backstage/automation/invite_users_selector.tsx
+++ b/webapp/src/components/backstage/automation/invite_users_selector.tsx
@@ -53,6 +53,7 @@ const InviteUsersSelector: FC<Props> = (props: Props) => {
                 let nonInvitedProfiles: UserProfile[] = [];
 
                 if (term.trim().length === 0) {
+                    // Filter out all the undefined users, which will cast to false in the filter predicate
                     invitedProfiles = invitedUsers.filter((user) => user);
                     nonInvitedProfiles = data.filter(
                         (profile: UserProfile) => !props.userIds.includes(profile.id),

--- a/webapp/src/components/backstage/automation/invite_users_selector.tsx
+++ b/webapp/src/components/backstage/automation/invite_users_selector.tsx
@@ -10,7 +10,7 @@ import {ActionFunc} from 'mattermost-redux/types/actions';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
-import {getUser as fetchUser} from 'mattermost-redux/actions/users';
+import {getProfilesByIds} from 'mattermost-redux/actions/users';
 
 import Profile from 'src/components/profile/profile';
 
@@ -34,11 +34,7 @@ const InviteUsersSelector: FC<Props> = (props: Props) => {
     const invitedUsers = useSelector<GlobalState, UserProfile[]>((state: GlobalState) => props.userIds.map((id) => getUser(state, id)));
 
     useEffect(() => {
-        invitedUsers.forEach((user, idx) => {
-            if (!user) {
-                dispatch(fetchUser(props.userIds[idx]));
-            }
-        });
+        dispatch(getProfilesByIds(props.userIds));
     }, [props.userIds]);
 
     // Update the options whenever the passed user IDs or the search term are updated


### PR DESCRIPTION
#### Summary
The component was filtering the invited members out of the list that is fetched when the component is mounted. This list is capped at 100 users (the default for getUsers), so if the invited member was not originally there, it was not shown in the component.

This PR fixes the bug by pre-fetching all the invited members. In particular:
1. Fetch all the invited members on component mount.
2. If the user has not typed anything in the search box, just pass the fetched members to react-select as the group of invited members. All the invited members will be there.
3. If the user has typed something in the search box, rely on the server-side filtering. This is the tricky part: if there are more than 100 hits for your search term, it is possible that the invited member is still lost, but this also happens with non-invited members. The alternative is to do the filtering client-side, but I took a look at the filtering on the server side to try and replicate it and it's quite complex: we're filtering not only by username, but also by the first and last name, and I am sure t]at if we try to replicate that here, it will come back to bite us. That's why I decided it was an acceptable trade-off to rely on the server filtering in this case.

This is a working fix for this dot release, but we still need something more robust for the future (for example, we don't even have pagination in the fetching of the users). I added this to my now long list of things I want to tackle as part of https://mattermost.atlassian.net/browse/MM-32861

About the release itself: I created a branch from the v1.5.1 tag, release-v1.5.2, which is the base for this PR. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33439