### PR TITLE
MM-33310 "Message" in status update modal accepts empty character string

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -638,7 +638,13 @@ func (h *IncidentHandler) updateStatusDialog(w http.ResponseWriter, r *http.Requ
 
 	var options incident.StatusUpdateOptions
 	if message, ok := request.Submission[incident.DialogFieldMessageKey]; ok {
-		options.Message = message.(string)
+		options.Message = strings.TrimSpace(message.(string))
+	}
+
+	if options.Message == "" {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"errors": {"%s":"This field is required."}}`, incident.DialogFieldMessageKey)))
+		return
 	}
 
 	if reminderI, ok := request.Submission[incident.DialogFieldReminderInSecondsKey]; ok {

--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_list_spec.js
@@ -180,6 +180,7 @@ describe('rhs incident list', () => {
                     incidentId: incident.id,
                     userId,
                     teamId: teamId1,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });
@@ -1097,6 +1098,7 @@ describe('rhs incident list', () => {
                     incidentId,
                     userId: user2Id,
                     teamId: teamId1,
+                    message: 'ending',
                     status: 'Archived',
                 });
 
@@ -1147,6 +1149,7 @@ describe('rhs incident list', () => {
                     incidentId,
                     userId,
                     teamId: teamId1,
+                    message: 'ending',
                     status: 'Archived',
                 });
                 cy.verifyIncidentEnded(teamId1, incidentName);
@@ -1221,6 +1224,7 @@ describe('rhs incident list', () => {
                     incidentId: incident.id,
                     userId: user2Id,
                     teamId: teamId1,
+                    message: 'ending',
                     status: 'Archived',
                 });
 

--- a/tests-e2e/cypress/integration/frontstage/rhs/header_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/header_spec.js
@@ -136,6 +136,7 @@ describe('incident rhs > header', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'ending',
                     status: 'Resolved',
                 });
             });
@@ -165,6 +166,7 @@ describe('incident rhs > header', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });

--- a/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/open_spec.js
@@ -129,6 +129,7 @@ describe('incident rhs', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'resolved',
                     status: 'Resolved',
                 });
             });
@@ -158,6 +159,7 @@ describe('incident rhs', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });
@@ -226,6 +228,7 @@ describe('incident rhs', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'resolving',
                     status: 'Resolved',
                 });
             });
@@ -264,6 +267,7 @@ describe('incident rhs', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });
@@ -321,6 +325,7 @@ describe('incident rhs', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'resolving',
                     status: 'Resolved',
                 });
             });
@@ -357,6 +362,7 @@ describe('incident rhs', () => {
                     incidentId: incident.id,
                     userId,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });

--- a/tests-e2e/cypress/support/index.js
+++ b/tests-e2e/cypress/support/index.js
@@ -62,6 +62,7 @@ Cypress.Commands.add('endAllActiveIncidents', (teamId) => {
                     incidentId: incident.id,
                     userId: user.id,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });
@@ -75,6 +76,7 @@ Cypress.Commands.add('endAllActiveIncidents', (teamId) => {
                     incidentId: incident.id,
                     userId: user.id,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });
@@ -107,6 +109,7 @@ Cypress.Commands.add('endAllMyActiveIncidents', (teamId) => {
                     incidentId: incident.id,
                     userId: user.id,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });
@@ -120,6 +123,7 @@ Cypress.Commands.add('endAllMyActiveIncidents', (teamId) => {
                     incidentId: incident.id,
                     userId: user.id,
                     teamId,
+                    message: 'ending',
                     status: 'Archived',
                 });
             });


### PR DESCRIPTION
#### Summary
- Trimming and testing the submitted message, rejecting the interactive dialog request if the message is empty
- e2e tests

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-33310
