### PR TITLE
Fix E2E tests

### DIFF
--- a/tests-e2e/cypress/integration/frontstage/incident_rhs_checklist_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_rhs_checklist_spec.js
@@ -191,12 +191,12 @@ describe('incident rhs checklist', () => {
 
         it('assignee selector is shifted up if it falls below window', () => {
             // Hover over a checklist item at the end
-            cy.findAllByTestId('checkbox-item-container').eq(10).trigger('mouseover');
+            cy.findAllByTestId('checkbox-item-container').eq(10).trigger('mouseover').within(() => {
+                // Click the profile icon
+                cy.get('.icon-account-plus-outline').click().wait(TINY);
 
-            // Click the profile icon
-            cy.get('.icon-account-plus-outline').click().wait(TINY);
-
-            cy.isInViewport('.incident-user-select');
+                cy.isInViewport('.incident-user-select');
+            });
         });
     });
 });


### PR DESCRIPTION
#### Summary
This little guy was added recently:
![image](https://user-images.githubusercontent.com/3924815/112025852-e49db380-8b35-11eb-8425-68545cd24331.png)

This makes the `cy.get(.icon-account-plus-outline)` return two elements instead of one, so clicking on it was ambiguous. I simply isolated the calls to the checklist element itself.

Let's see if CI passes.

#### Ticket Link
--
