### PR TITLE
MM-34207: css issue with RHS timeline

### DIFF
--- a/webapp/src/components/rhs/rhs_timeline.tsx
+++ b/webapp/src/components/rhs/rhs_timeline.tsx
@@ -25,7 +25,6 @@ import {Incident} from 'src/types/incident';
 import {
     TimelineEvent,
     TimelineEventsFilter,
-    TimelineEventsFilterAll,
     TimelineEventType,
 } from 'src/types/rhs';
 import RHSTimelineEventItem from 'src/components/rhs/rhs_timeline_event_item';
@@ -181,6 +180,25 @@ const RHSTimeline = (props: Props) => {
         },
     ];
 
+    let timeline = null;
+    if (filteredEvents.length > 0) {
+        timeline = (
+            <Timeline data-testid='timeline-view'>
+                {
+                    filteredEvents.map((event) => (
+                        <RHSTimelineEventItem
+                            key={event.id}
+                            event={event}
+                            reportedAt={moment(props.incident.create_at)}
+                            channelNames={channelNamesMap}
+                            team={team}
+                        />
+                    ))
+                }
+            </Timeline>
+        );
+    }
+
     return (
         <>
             <Header>
@@ -198,19 +216,7 @@ const RHSTimeline = (props: Props) => {
                 renderView={renderView}
                 style={{position: 'absolute'}}
             >
-                <Timeline data-testid='timeline-view'>
-                    {
-                        filteredEvents.map((event) => (
-                            <RHSTimelineEventItem
-                                key={event.id}
-                                event={event}
-                                reportedAt={moment(props.incident.create_at)}
-                                channelNames={channelNamesMap}
-                                team={team}
-                            />
-                        ))
-                    }
-                </Timeline>
+                {timeline}
             </Scrollbars>
         </>
     );


### PR DESCRIPTION
#### Summary
- @prapti noticed an edge case when the filter filtered out all events, a piece of the timeline's line still showed. So don't return the Timeline element if there are no filtered events. https://github.com/mattermost/mattermost-plugin-incident-collaboration/pull/487#pullrequestreview-618079651

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-34207
- https://github.com/mattermost/mattermost-plugin-incident-collaboration/pull/487#pullrequestreview-618079651