### PR TITLE
golangci: disable fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,8 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - fieldalignment
 
 issues:
   exclude:


### PR DESCRIPTION
#### Summary
Eliminate a number of unnecessary warnings for our product (at this time), e.g.:
```sh
> golangci-lint run ./...
server/config/configuration.go:14:20: fieldalignment: struct with 48 pointer bytes could be 40 (govet)
type Configuration struct {
                   ^
server/config/service.go:15:18: fieldalignment: struct with 56 pointer bytes could be 32 (govet)
type ServiceImpl struct {
                 ^
server/bot/bot.go:12:10: fieldalignment: struct with 48 pointer bytes could be 40 (govet)
type Bot struct {
         ^
```