### PR TITLE
MM-33942: fix preferences styling

### DIFF
--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -84,6 +84,7 @@ const commonSelectStyle = css`
 
     .channel-selector__option--is-selected {
         background-color: var(--center-channel-color-08);
+        color: inherit;
     }
 
     .channel-selector__option--is-focused {


### PR DESCRIPTION
#### Summary
Ensure the font color is inherited, fixing this:
<img width="731" alt="image" src="https://user-images.githubusercontent.com/1023171/112860082-de558d00-9089-11eb-952f-55a9b186e451.png">

to render like this:
<img width="726" alt="image" src="https://user-images.githubusercontent.com/1023171/112859894-ab12fe00-9089-11eb-9c61-194097050b63.png">

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-33942