### PR TITLE
Retrieve only active users

### DIFF
--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -21,7 +21,7 @@ import {Playbook, Checklist, emptyPlaybook} from 'src/types/playbook';
 import {savePlaybook, clientFetchPlaybook} from 'src/client';
 import {StagesAndStepsEdit} from 'src/components/backstage/stages_and_steps_edit';
 import ConfirmModal from 'src/components/widgets/confirmation_modal';
-import {ErrorPageTypes, TEMPLATE_TITLE_KEY} from 'src/constants';
+import {ErrorPageTypes, TEMPLATE_TITLE_KEY, PROFILE_CHUNK_SIZE} from 'src/constants';
 import {PrimaryButton} from 'src/components/assets/buttons';
 import {BackstageNavbar, BackstageNavbarIcon} from 'src/components/backstage/backstage';
 import {AutomationSettings} from 'src/components/backstage/automation/settings';
@@ -369,7 +369,7 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
     };
 
     const getUsers = () => {
-        return dispatch(getProfilesInTeam(props.currentTeam.id, 0));
+        return dispatch(getProfilesInTeam(props.currentTeam.id, 0, PROFILE_CHUNK_SIZE, '', {active: true}));
     };
 
     const handleBroadcastInput = (channelId: string | undefined) => {


### PR DESCRIPTION
#### Summary
The default when searching users through `GET /users/search` is to return only the active ones, but we need to be specific when retrieving all users in a team via `GET /users`, as the default is to return active and inactive users.

It is actually a bit weird, as there are [two boolean query parameters, `active` and `inactive`](https://api.mattermost.com/#tag/users/paths/~1users/get), mutually exclusive, that both default to false. They actually mean "only active" and "only inactive", so both being false means "both active and inactive".

Anyway, the change just adds the `active: true` option to get only active users, and I had to fill the other precedent parameters with their default values.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33809
