### PR TITLE
MM-34479 System console setting for which teams plugin is enabled on.

### DIFF
--- a/client/incident.go
+++ b/client/incident.go
@@ -169,6 +169,7 @@ type GetIncidentsResults struct {
 	PageCount  int        `json:"page_count"`
 	HasMore    bool       `json:"has_more"`
 	Items      []Incident `json:"items"`
+	Disabled   bool       `json:"disabled"`
 }
 
 // StatusUpdateOptions are the fields required to update an incident's status

--- a/plugin.json
+++ b/plugin.json
@@ -20,6 +20,10 @@
     "settings_schema": {
         "header": "Incident Collaboration requires a Mattermost Cloud or Mattermost E20 License.",
         "footer": "",
-        "settings": []
+        "settings": [{
+            "key": "EnabledTeams",
+            "type": "custom",
+            "display_name": "Enabled Teams:"
+        }]
     }
 }

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mock_poster "github.com/mattermost/mattermost-plugin-incident-collaboration/server/bot/mocks"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/config"
 	mock_config "github.com/mattermost/mattermost-plugin-incident-collaboration/server/config/mocks"
 	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/playbook"
 	mock_playbook "github.com/mattermost/mattermost-plugin-incident-collaboration/server/playbook/mocks"
@@ -140,11 +141,17 @@ func TestPlaybooks(t *testing.T) {
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
 		logger = mock_poster.NewMockLogger(mockCtrl)
-		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger)
+		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger, configService)
 
 		configService.EXPECT().
 			IsLicensed().
 			Return(true)
+
+		configService.EXPECT().
+			GetConfiguration().
+			Return(&config.Configuration{
+				EnabledTeams: []string{},
+			})
 	}
 
 	t.Run("create playbook, unlicensed", func(t *testing.T) {
@@ -155,7 +162,7 @@ func TestPlaybooks(t *testing.T) {
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
 		logger = mock_poster.NewMockLogger(mockCtrl)
-		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger)
+		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger, configService)
 
 		configService.EXPECT().
 			IsLicensed().
@@ -949,7 +956,7 @@ func TestSortingPlaybooks(t *testing.T) {
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
 		logger = mock_poster.NewMockLogger(mockCtrl)
-		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger)
+		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger, configService)
 
 		configService.EXPECT().
 			IsLicensed().
@@ -1142,7 +1149,7 @@ func TestPagingPlaybooks(t *testing.T) {
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
 		logger = mock_poster.NewMockLogger(mockCtrl)
-		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger)
+		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger, configService)
 
 		configService.EXPECT().
 			IsLicensed().

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -1418,6 +1418,11 @@ func (r *Runner) Execute() error {
 		return nil
 	}
 
+	if !permissions.IsOnEnabledTeam(r.args.TeamId, r.configService) {
+		r.postCommandResponse("Not enabled on this team.")
+		return nil
+	}
+
 	switch cmd {
 	case "start":
 		r.actionStart(parameters)

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -12,6 +12,9 @@ package config
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type Configuration struct {
+	// EnabledTeams a list of team IDs the plugin is enabled for
+	EnabledTeams []string
+
 	// ** The following are NOT stored on the server
 	// AdminUserIDs contains a list of user IDs that are allowed
 	// to administer plugin functions, even if not Mattermost sysadmins.

--- a/server/permissions/permissions.go
+++ b/server/permissions/permissions.go
@@ -3,6 +3,7 @@ package permissions
 import (
 	"github.com/pkg/errors"
 
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/config"
 	"github.com/mattermost/mattermost-server/v5/model"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
@@ -155,4 +156,20 @@ func IsChannelActiveInTeam(channelID string, expectedTeamID string, pluginAPI *p
 	}
 
 	return nil
+}
+
+func IsOnEnabledTeam(teamID string, cfgService config.Service) bool {
+	enabledTeams := cfgService.GetConfiguration().EnabledTeams
+
+	if len(enabledTeams) == 0 {
+		return true
+	}
+
+	for _, enabledTeam := range enabledTeams {
+		if enabledTeam == teamID {
+			return true
+		}
+	}
+
+	return false
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -157,7 +157,7 @@ func (p *Plugin) OnActivate() error {
 
 	p.playbookService = playbook.NewService(playbookStore, p.bot, telemetryClient)
 
-	api.NewPlaybookHandler(p.handler.APIRouter, p.playbookService, pluginAPIClient, p.bot)
+	api.NewPlaybookHandler(p.handler.APIRouter, p.playbookService, pluginAPIClient, p.bot, p.config)
 	api.NewIncidentHandler(
 		p.handler.APIRouter,
 		p.incidentService,
@@ -166,6 +166,7 @@ func (p *Plugin) OnActivate() error {
 		p.bot,
 		p.bot,
 		telemetryClient,
+		p.config,
 	)
 	api.NewStatsHandler(p.handler.APIRouter, pluginAPIClient, p.bot, statsStore)
 

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -34,6 +34,8 @@ import {
     SetRHSState,
     SetRHSTabState,
     SetTriggerId,
+    RECEIVED_TEAM_DISABLED,
+    ReceivedTeamDisabled,
 } from './types/actions';
 
 import {clientExecuteCommand} from './client';
@@ -148,6 +150,11 @@ export const incidentUpdated = (incident: Incident): IncidentUpdated => ({
 export const receivedTeamIncidents = (incidents: Incident[]): ReceivedTeamIncidents => ({
     type: RECEIVED_TEAM_INCIDENTS,
     incidents,
+});
+
+export const receivedDisabledOnTeam = (teamId: string): ReceivedTeamDisabled => ({
+    type: RECEIVED_TEAM_DISABLED,
+    teamId,
 });
 
 export const removedFromIncidentChannel = (channelId: string): RemovedFromIncidentChannel => ({

--- a/webapp/src/components/assets/icons/channel_header_button.tsx
+++ b/webapp/src/components/assets/icons/channel_header_button.tsx
@@ -6,7 +6,7 @@ import {useSelector} from 'react-redux';
 
 import {createGlobalStyle} from 'styled-components';
 
-import {isIncidentRHSOpen, isDisabled} from 'src/selectors';
+import {isIncidentRHSOpen, isDisabledOnCurrentTeam} from 'src/selectors';
 
 import IncidentIcon, {Ref as IncidentIconRef} from './incident_icon';
 
@@ -19,7 +19,7 @@ const DisabledStyle = createGlobalStyle`
 const ChannelHeaderButton: FC = () => {
     const myRef = useRef<IncidentIconRef>(null);
     const isRHSOpen = useSelector(isIncidentRHSOpen);
-    const disabled = useSelector(isDisabled);
+    const disabled = useSelector(isDisabledOnCurrentTeam);
 
     // If it has been mounted, we know our parent is always a button.
     const parent = myRef?.current ? myRef?.current?.parentNode as HTMLButtonElement : null;

--- a/webapp/src/components/assets/icons/channel_header_button.tsx
+++ b/webapp/src/components/assets/icons/channel_header_button.tsx
@@ -4,13 +4,22 @@
 import React, {useRef, FC} from 'react';
 import {useSelector} from 'react-redux';
 
-import {isIncidentRHSOpen} from 'src/selectors';
+import {createGlobalStyle} from 'styled-components';
+
+import {isIncidentRHSOpen, isDisabled} from 'src/selectors';
 
 import IncidentIcon, {Ref as IncidentIconRef} from './incident_icon';
+
+const DisabledStyle = createGlobalStyle`
+    .plugin-icon-hide {
+        display: none;
+    }
+`;
 
 const ChannelHeaderButton: FC = () => {
     const myRef = useRef<IncidentIconRef>(null);
     const isRHSOpen = useSelector(isIncidentRHSOpen);
+    const disabled = useSelector(isDisabled);
 
     // If it has been mounted, we know our parent is always a button.
     const parent = myRef?.current ? myRef?.current?.parentNode as HTMLButtonElement : null;
@@ -20,13 +29,22 @@ const ChannelHeaderButton: FC = () => {
         } else {
             parent.classList.remove('channel-header__icon--active');
         }
+
+        if (disabled) {
+            parent.classList.add('plugin-icon-hide');
+        } else {
+            parent.classList.remove('plugin-icon-hide');
+        }
     }
 
     return (
-        <IncidentIcon
-            id='incidentIcon'
-            ref={myRef}
-        />
+        <>
+            <DisabledStyle/>
+            <IncidentIcon
+                id='incidentIcon'
+                ref={myRef}
+            />
+        </>
     );
 };
 

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -9,11 +9,8 @@ import {GlobalState} from 'mattermost-redux/types/store';
 
 //@ts-ignore Webapp imports don't work properly
 import {PluginRegistry} from 'mattermost-webapp/plugins/registry';
-import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import WebsocketEvents from 'mattermost-redux/constants/websocket';
 
-import {isMobile} from 'src/mobile';
-import {navigateToTeamPluginUrl} from 'src/browser_routing';
 import {makeRHSOpener} from 'src/rhs_opener';
 import {makeSlashCommandHook} from 'src/slash_command';
 
@@ -44,31 +41,7 @@ import {
 import RegistryWrapper from './registry_wrapper';
 import {isE20LicensedOrDevelopment} from './license';
 import SystemConsoleEnabledTeams from './system_console_enabled_teams';
-import {isDisabled} from './selectors';
-
-function makeUpdateMainMenu(registry: PluginRegistry, store: Store<GlobalState>): () => Promise<void> {
-    let mainMenuActionId: string | null;
-
-    return async () => {
-        const disable = isDisabled(store.getState());
-        const show = !disable && !isMobile() && isE20LicensedOrDevelopment(store);
-
-        if (mainMenuActionId && !show) {
-            const temp = mainMenuActionId;
-            mainMenuActionId = null;
-            registry.unregisterComponent(temp);
-        } else if (!mainMenuActionId && show) {
-            mainMenuActionId = 'notnull';
-            mainMenuActionId = registry.registerMainMenuAction(
-                'Incident Collaboration',
-                () => {
-                    const team = getCurrentTeam(store.getState());
-                    navigateToTeamPluginUrl(team.name, '/stats');
-                },
-            );
-        }
-    };
-}
+import {makeUpdateMainMenu} from './make_update_main_menu';
 
 export default class Plugin {
     public initialize(registry: PluginRegistry, store: Store<GlobalState>): void {

--- a/webapp/src/make_update_main_menu.ts
+++ b/webapp/src/make_update_main_menu.ts
@@ -1,0 +1,39 @@
+import {Store} from 'redux';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+
+//@ts-ignore Webapp imports don't work properly
+import {PluginRegistry} from 'mattermost-webapp/plugins/registry';
+
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import {isDisabledOnCurrentTeam} from './selectors';
+import {isMobile} from './mobile';
+import {isE20LicensedOrDevelopment} from './license';
+
+import {navigateToTeamPluginUrl} from './browser_routing';
+
+export function makeUpdateMainMenu(registry: PluginRegistry, store: Store<GlobalState>): () => Promise<void> {
+    let mainMenuActionId: string | null;
+
+    return async () => {
+        const disable = isDisabledOnCurrentTeam(store.getState());
+        const show = !disable && !isMobile() && isE20LicensedOrDevelopment(store);
+
+        if (mainMenuActionId && !show) {
+            const temp = mainMenuActionId;
+            mainMenuActionId = null;
+            registry.unregisterComponent(temp);
+        } else if (!mainMenuActionId && show) {
+            mainMenuActionId = 'notnull';
+            mainMenuActionId = registry.registerMainMenuAction(
+                'Incident Collaboration',
+                () => {
+                    const team = getCurrentTeam(store.getState());
+                    navigateToTeamPluginUrl(team.name, '/stats');
+                },
+            );
+        }
+    };
+}
+

--- a/webapp/src/reducer.test.ts
+++ b/webapp/src/reducer.test.ts
@@ -30,6 +30,7 @@ describe('myIncidentsByTeam', () => {
             };
             const expectedState = state;
 
+            // @ts-ignore
             expect(reducer(state, action)).toStrictEqual(expectedState);
         });
 
@@ -58,6 +59,7 @@ describe('myIncidentsByTeam', () => {
                 },
             });
 
+            // @ts-ignore
             expect(reducer(state, action)).toEqual(expectedState);
         });
     });

--- a/webapp/src/reducer.ts
+++ b/webapp/src/reducer.ts
@@ -23,7 +23,7 @@ import {
     INCIDENT_UPDATED,
     REMOVED_FROM_INCIDENT_CHANNEL,
     SetRHSTabState,
-    SET_RHS_TAB_STATE, SetRHSEventsFilter, SET_RHS_EVENTS_FILTER,
+    SET_RHS_TAB_STATE, SetRHSEventsFilter, SET_RHS_EVENTS_FILTER, ReceivedTeamDisabled, RECEIVED_TEAM_DISABLED,
 } from 'src/types/actions';
 import {Incident} from 'src/types/incident';
 
@@ -66,7 +66,11 @@ function rhsState(state = RHSState.ViewingIncident, action: SetRHSState) {
 // myIncidentsByTeam is a map of teamId->{channelId->incidents} for which the current user is an incident member. Note
 // that it is lazy loaded on team change, but will also track incremental updates as provided by
 // websocket events.
-const myIncidentsByTeam = (state: Record<string, Record<string, Incident>> = {}, action: IncidentCreated | IncidentUpdated | ReceivedTeamIncidents | RemovedFromIncidentChannel) => {
+// Aditnally it handles the plugin being disabled on the team
+const myIncidentsByTeam = (
+    state: Record<string, Record<string, Incident>> = {},
+    action: IncidentCreated | IncidentUpdated | ReceivedTeamIncidents | RemovedFromIncidentChannel | ReceivedTeamDisabled,
+) => {
     switch (action.type) {
     case INCIDENT_CREATED: {
         const incidentCreatedAction = action as IncidentCreated;
@@ -126,6 +130,13 @@ const myIncidentsByTeam = (state: Record<string, Record<string, Incident>> = {},
         };
         delete newState[teamId][channelId];
         return newState;
+    }
+    case RECEIVED_TEAM_DISABLED: {
+        const teamDisabledAction = action as ReceivedTeamDisabled;
+        return {
+            ...state,
+            [teamDisabledAction.teamId]: false,
+        };
     }
     default:
         return state;

--- a/webapp/src/rhs_opener.ts
+++ b/webapp/src/rhs_opener.ts
@@ -10,7 +10,7 @@ import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {fetchIncidents} from 'src/client';
 
 import {isIncidentRHSOpen, inIncidentChannel} from 'src/selectors';
-import {toggleRHS, receivedTeamIncidents} from 'src/actions';
+import {toggleRHS, receivedTeamIncidents, receivedDisabledOnTeam} from 'src/actions';
 
 export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
     let currentTeamId = '';
@@ -38,7 +38,11 @@ export function makeRHSOpener(store: Store<GlobalState>): () => Promise<void> {
                 team_id: currentTeam.id,
                 member_id: currentUserId,
             });
-            store.dispatch(receivedTeamIncidents(fetched.items));
+            if (fetched.disabled) {
+                store.dispatch(receivedDisabledOnTeam(currentTeam.id));
+            } else {
+                store.dispatch(receivedTeamIncidents(fetched.items));
+            }
         }
 
         // Only consider opening the RHS if the channel has changed and wasn't already seen as

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -29,6 +29,8 @@ export const getIsRhsExpanded = (state: WebGlobalState): boolean => state.views.
 
 export const clientId = (state: GlobalState): string => pluginState(state).clientId;
 
+export const isDisabled = (state: GlobalState): boolean => pluginState(state).myIncidentsByTeam[getCurrentTeamId(state)] === false;
+
 // reminder: myIncidentsByTeam indexes teamId->channelId->incident
 const myIncidentsByTeam = (state: GlobalState): Record<string, Record<string, Incident>> =>
     pluginState(state).myIncidentsByTeam;

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -29,7 +29,7 @@ export const getIsRhsExpanded = (state: WebGlobalState): boolean => state.views.
 
 export const clientId = (state: GlobalState): string => pluginState(state).clientId;
 
-export const isDisabled = (state: GlobalState): boolean => pluginState(state).myIncidentsByTeam[getCurrentTeamId(state)] === false;
+export const isDisabledOnCurrentTeam = (state: GlobalState): boolean => pluginState(state).myIncidentsByTeam[getCurrentTeamId(state)] === false;
 
 // reminder: myIncidentsByTeam indexes teamId->channelId->incident
 const myIncidentsByTeam = (state: GlobalState): Record<string, Record<string, Incident>> =>

--- a/webapp/src/system_console_enabled_teams.tsx
+++ b/webapp/src/system_console_enabled_teams.tsx
@@ -1,0 +1,92 @@
+import React, {FC} from 'react';
+
+import {useSelector} from 'react-redux';
+import {getMyTeams, getTeam} from 'mattermost-redux/selectors/entities/teams';
+import {OptionsType} from 'react-select';
+
+import {Team} from 'mattermost-redux/types/teams';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+
+import {StyledAsyncSelect} from './components/backstage/styles';
+
+interface TeamSelectorProps {
+    teamsSlected: string[]
+    onTeamsSelected: (teams: string[]) => void;
+}
+
+type GetTeamType = (teamID: string) => Team
+
+const TeamSelector: FC<TeamSelectorProps> = (props: TeamSelectorProps) => {
+    const selectableTeams = useSelector<GlobalState, Team[]>(getMyTeams);
+    const getTeamFromID = useSelector<GlobalState, GetTeamType>((state) => (teamId) => getTeam(state, teamId) || {display_name: 'Unknown Team', id: teamId});
+
+    const onChange = (teams: Team[] | null) => {
+        if (!teams) {
+            props.onTeamsSelected([]);
+            return;
+        }
+        props.onTeamsSelected(teams.map((team: Team) => team.id));
+    };
+
+    const getOptionValue = (team: Team) => {
+        return team.id;
+    };
+
+    const formatOptionLabel = (team: Team) => {
+        return (
+            <>
+                {team.display_name}
+            </>
+        );
+    };
+
+    const loadTeams = (term: string, callback: (options: OptionsType<Team>) => void) => {
+        if (term.trim().length === 0) {
+            callback(selectableTeams);
+        } else {
+            callback(selectableTeams.filter((team) => (
+                team.name.toLowerCase().includes(term.toLowerCase()) ||
+                    team.display_name.toLowerCase().includes(term.toLowerCase()) ||
+                    team.id.toLowerCase() === term.toLowerCase()
+            )));
+        }
+    };
+
+    return (
+        <StyledAsyncSelect
+            isMulti={true}
+            cacheOptions={false}
+            defaultOptions={true}
+            loadOptions={loadTeams}
+            onChange={onChange}
+            getOptionValue={getOptionValue}
+            formatOptionLabel={formatOptionLabel}
+            isClearable={false}
+            value={props.teamsSlected.map(getTeamFromID)}
+        />
+    );
+};
+
+interface SystemConsoleEnabledTeamsProps {
+    id: string
+    value?: string[]
+    onChange: (id: string, value: string[]) => void
+    setSaveNeeded: () => void
+}
+
+const SystemConsoleEnabledTeams: FC<SystemConsoleEnabledTeamsProps> = (props: SystemConsoleEnabledTeamsProps) => {
+    const onTeamsSelected = (teams: string[]) => {
+        props.onChange(props.id, teams);
+        props.setSaveNeeded();
+    };
+
+    return (
+        <TeamSelector
+            onTeamsSelected={onTeamsSelected}
+            teamsSlected={props.value || []}
+        />
+    );
+};
+
+export default SystemConsoleEnabledTeams;

--- a/webapp/src/types/actions.ts
+++ b/webapp/src/types/actions.ts
@@ -13,6 +13,7 @@ export const SET_CLIENT_ID = pluginId + '_set_client_id';
 export const INCIDENT_CREATED = pluginId + '_incident_created';
 export const INCIDENT_UPDATED = pluginId + '_incident_updated';
 export const RECEIVED_TEAM_INCIDENTS = pluginId + '_received_team_incident_channels';
+export const RECEIVED_TEAM_DISABLED = pluginId + '_received_team_disabled';
 export const REMOVED_FROM_INCIDENT_CHANNEL = pluginId + '_removed_from_incident_channel';
 export const SET_RHS_STATE = pluginId + '_set_rhs_state';
 export const SET_RHS_TAB_STATE = pluginId + '_set_rhs_tab_state';
@@ -51,6 +52,11 @@ export interface IncidentUpdated {
 export interface ReceivedTeamIncidents {
     type: typeof RECEIVED_TEAM_INCIDENTS;
     incidents: Incident[];
+}
+
+export interface ReceivedTeamDisabled {
+    type: typeof RECEIVED_TEAM_DISABLED;
+    teamId: string
 }
 
 export interface RemovedFromIncidentChannel {

--- a/webapp/src/types/incident.ts
+++ b/webapp/src/types/incident.ts
@@ -48,6 +48,7 @@ export interface FetchIncidentsReturn {
     page_count: number;
     has_more: boolean;
     items: Incident[];
+    disabled?: boolean;
 }
 
 export enum IncidentStatus {
@@ -143,6 +144,7 @@ export interface FetchIncidentsParams {
     commander_user_id?: string;
     search_term?: string;
     member_id?: string;
+    disabled?: boolean;
 }
 
 export interface FetchPlaybooksParams {


### PR DESCRIPTION
#### Summary
Adds a system console setting to limit which teams the plugin is enabled on.

- When you are on a non-enabled team the main menu item and header icon disappear.
- The API only restricts creating incidents and playbooks. Reads and incident modifications are still possible. However listing incidents is not.
- All slash commands are disabled on teams for which the plugin is disabled. However the autocomplete will still suggest them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34479
