### PR TITLE
stop testing build/sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,6 @@ endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run test;
 endif
-ifneq ($(wildcard ./build/sync/plan/.),)
-	cd ./build/sync && $(GO) test -v $(GO_TEST_FLAGS) ./...
-endif
 
 ## Creates a coverage report for the server code.
 .PHONY: coverage


### PR DESCRIPTION
#### Summary
We don't use this utility, but it takes upwards of 60s+ when running `make test`. Eliminate it.

#### Ticket Link
None.