### PR TITLE
MM-26944: expose playbooks service in Go client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 
 	"github.com/google/go-querystring/query"
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -37,6 +38,8 @@ type Client struct {
 
 	// Incidents is a collection of methods used to interact with incidents.
 	Incidents *IncidentsService
+	// Playbooks is a collection of methods used to interact with playbooks.
+	Playbooks *PlaybooksService
 }
 
 // New creates a new instance of Client using the configuration from the given Mattermost Client.
@@ -58,6 +61,7 @@ func newClient(mattermostSiteURL string, httpClient *http.Client) (*Client, erro
 
 	c := &Client{client: httpClient, BaseURL: siteURL, UserAgent: userAgent}
 	c.Incidents = &IncidentsService{c}
+	c.Playbooks = &PlaybooksService{c}
 	return c, nil
 }
 
@@ -176,6 +180,20 @@ func checkResponse(r *http.Response) error {
 	return errorResponse
 }
 
+// addOption adds the given parameter as an URL query parameters to s.
+func addOption(s string, name, value string) (string, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return s, errors.Wrapf(err, "failed to parse %s", s)
+	}
+
+	qa := u.Query()
+	qa.Add(name, value)
+	u.RawQuery = qa.Encode()
+
+	return u.String(), nil
+}
+
 // addOptions adds the parameters in opts as URL query parameters to s. opts
 // must be a struct whose fields may contain "url" tags.
 func addOptions(s string, opts interface{}) (string, error) {
@@ -194,6 +212,29 @@ func addOptions(s string, opts interface{}) (string, error) {
 		return s, errors.Wrapf(err, "failed to opts %+v", opts)
 	}
 
-	u.RawQuery = qs.Encode()
+	// Append to the existing query parameters.
+	qa := u.Query()
+	for key, values := range qs {
+		for _, value := range values {
+			qa.Add(key, value)
+		}
+	}
+
+	u.RawQuery = qa.Encode()
+	return u.String(), nil
+}
+
+// addPaginationOptions adds the given pagination parameters as URL query parameters to s.
+func addPaginationOptions(s string, page, perPage int) (string, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return s, errors.Wrapf(err, "failed to parse %s", s)
+	}
+
+	qa := u.Query()
+	qa.Add("page", strconv.Itoa(page))
+	qa.Add("per_page", strconv.Itoa(perPage))
+	u.RawQuery = qa.Encode()
+
 	return u.String(), nil
 }

--- a/client/incident.go
+++ b/client/incident.go
@@ -103,6 +103,15 @@ const (
 
 	// SortByEndAt sorts by the "end_at" field.
 	SortByEndAt Sort = "end_at"
+
+	// SortBySteps sorts playbooks by the number of steps in the playbook.
+	SortBySteps Sort = "steps"
+
+	// SortByStages sorts playbooks by the number of stages in the playbook.
+	SortByStages Sort = "stages"
+
+	// SortByTitle sorts by the "title" field.
+	SortByTitle Sort = "title"
 )
 
 // SortDirection determines whether results are sorted ascending or descending.
@@ -119,12 +128,6 @@ const (
 // IncidentListOptions specifies the optional parameters to the
 // IncidentsService.List method.
 type IncidentListOptions struct {
-	// For paginated result sets, page of results to retrieve. 0 based indx.
-	Page int `url:"page,omitempty"`
-
-	// For paginated result sets, the number of results to include per page.
-	PerPage int `url:"per_page,omitempty"`
-
 	// TeamID filters incidents to those in the given team.
 	TeamID string `url:"team_id,omitempty"`
 

--- a/client/incidents.go
+++ b/client/incidents.go
@@ -70,11 +70,15 @@ func (s *IncidentsService) GetMetadata(ctx context.Context, incidentID string) (
 }
 
 // List the incidents.
-func (s *IncidentsService) List(ctx context.Context, opts IncidentListOptions) (*GetIncidentsResults, error) {
+func (s *IncidentsService) List(ctx context.Context, page, perPage int, opts IncidentListOptions) (*GetIncidentsResults, error) {
 	incidentURL := "incidents"
 	incidentURL, err := addOptions(incidentURL, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build options: %w", err)
+	}
+	incidentURL, err = addPaginationOptions(incidentURL, page, perPage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build pagination options: %w", err)
 	}
 
 	req, err := s.client.newRequest(http.MethodGet, incidentURL, nil)

--- a/client/playbook.go
+++ b/client/playbook.go
@@ -16,6 +16,12 @@ type Playbook struct {
 	BroadcastChannelID          string      `json:"broadcast_channel_id"`
 	ReminderMessageTemplate     string      `json:"reminder_message_template"`
 	ReminderTimerDefaultSeconds int64       `json:"reminder_timer_default_seconds"`
+	InvitedUserIDs              []string    `json:"invited_user_ids"`
+	InviteUsersEnabled          bool        `json:"invite_users_enabled"`
+	DefaultCommanderID          string      `json:"default_commander_id"`
+	DefaultCommanderEnabled     bool        `json:"default_commander_enabled"`
+	AnnouncementChannelID       string      `json:"announcement_channel_id"`
+	AnnouncementChannelEnabled  bool        `json:"announcement_channel_enabled"`
 }
 
 // Checklist represents a checklist in a playbook
@@ -38,4 +44,40 @@ type ChecklistItem struct {
 	Command                string `json:"command"`
 	CommandLastRun         int64  `json:"command_last_run"`
 	Description            string `json:"description"`
+}
+
+// PlaybookCreateOptions specifies the parameters for PlaybooksService.Create method.
+type PlaybookCreateOptions struct {
+	Title                       string      `json:"title"`
+	Description                 string      `json:"description"`
+	TeamID                      string      `json:"team_id"`
+	CreatePublicIncident        bool        `json:"create_public_incident"`
+	Checklists                  []Checklist `json:"checklists"`
+	MemberIDs                   []string    `json:"member_ids"`
+	BroadcastChannelID          string      `json:"broadcast_channel_id"`
+	ReminderMessageTemplate     string      `json:"reminder_message_template"`
+	ReminderTimerDefaultSeconds int64       `json:"reminder_timer_default_seconds"`
+	InvitedUserIDs              []string    `json:"invited_user_ids"`
+	InviteUsersEnabled          bool        `json:"invite_users_enabled"`
+	DefaultCommanderID          string      `json:"default_commander_id"`
+	DefaultCommanderEnabled     bool        `json:"default_commander_enabled"`
+	AnnouncementChannelID       string      `json:"announcement_channel_id"`
+	AnnouncementChannelEnabled  bool        `json:"announcement_channel_enabled"`
+}
+
+// PlaybookListOptions specifies the optional parameters to the
+// PlaybooksService.List method.
+type PlaybookListOptions struct {
+	// MemberOnly filters playbooks to those for which the current user is a member.
+	MemberOnly bool `url:"member_only,omitempty"`
+
+	Sort      Sort          `url:"sort,omitempty"`
+	Direction SortDirection `url:"direction,omitempty"`
+}
+
+type GetPlaybooksResults struct {
+	TotalCount int        `json:"total_count"`
+	PageCount  int        `json:"page_count"`
+	HasMore    bool       `json:"has_more"`
+	Items      []Playbook `json:"items"`
 }

--- a/client/playbooks.go
+++ b/client/playbooks.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// PlaybooksService handles communication with the playbook related
+// methods of the Playbook Collaboration API.
+type PlaybooksService struct {
+	client *Client
+}
+
+// Get a playbook.
+func (s *PlaybooksService) Get(ctx context.Context, playbookID string) (*Playbook, error) {
+	playbookURL := fmt.Sprintf("playbooks/%s", playbookID)
+	req, err := s.client.newRequest(http.MethodGet, playbookURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	playbook := new(Playbook)
+	resp, err := s.client.do(ctx, req, playbook)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	return playbook, nil
+}
+
+// List the playbooks.
+func (s *PlaybooksService) List(ctx context.Context, teamId string, page, perPage int, opts PlaybookListOptions) (*GetPlaybooksResults, error) {
+	playbookURL := "playbooks"
+	playbookURL, err := addOption(playbookURL, "team_id", teamId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build options: %w", err)
+	}
+
+	playbookURL, err = addPaginationOptions(playbookURL, page, perPage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build pagination options: %w", err)
+	}
+
+	playbookURL, err = addOptions(playbookURL, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build options: %w", err)
+	}
+
+	req, err := s.client.newRequest(http.MethodGet, playbookURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	result := &GetPlaybooksResults{}
+	resp, err := s.client.do(ctx, req, result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	resp.Body.Close()
+
+	return result, nil
+}
+
+// Create a playbook.
+func (s *PlaybooksService) Create(ctx context.Context, opts PlaybookCreateOptions) (*Playbook, error) {
+	playbookURL := "playbooks"
+	req, err := s.client.newRequest(http.MethodPost, playbookURL, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	playbook := new(Playbook)
+	resp, err := s.client.do(ctx, req, playbook)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("expected status code %d", http.StatusCreated)
+	}
+
+	return playbook, nil
+}
+
+func (s *PlaybooksService) Update(ctx context.Context, playbook Playbook) error {
+	updateURL := fmt.Sprintf("playbooks/%s", playbook.ID)
+	req, err := s.client.newRequest(http.MethodPut, updateURL, playbook)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *PlaybooksService) Delete(ctx context.Context, playbookID string) error {
+	updateURL := fmt.Sprintf("playbooks/%s", playbookID)
+	req, err := s.client.newRequest(http.MethodDelete, updateURL, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/client/playbooks_test.go
+++ b/client/playbooks_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
-func ExampleIncidentsService_Get() {
+func ExamplePlaybooksService_Get() {
 	ctx := context.Background()
 
 	client4 := model.NewAPIv4Client("http://localhost:8065")
@@ -20,16 +20,16 @@ func ExampleIncidentsService_Get() {
 		log.Fatal(err)
 	}
 
-	incidentID := "h4n3h7s1qjf5pkis4dn6cuxgwa"
-	incident, err := c.Incidents.Get(ctx, incidentID)
+	playbookID := "h4n3h7s1qjf5pkis4dn6cuxgwa"
+	playbook, err := c.Playbooks.Get(ctx, playbookID)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("Incident Name: %s\n", incident.Name)
+	fmt.Printf("Playbook Name: %s\n", playbook.Title)
 }
 
-func ExampleIncidentsService_List() {
+func ExamplePlaybooksService_List() {
 	ctx := context.Background()
 
 	client4 := model.NewAPIv4Client("http://localhost:8065")
@@ -51,10 +51,9 @@ func ExampleIncidentsService_List() {
 		log.Fatal(err)
 	}
 
-	var incidents []client.Incident
+	var playbooks []client.Playbook
 	for page := 0; ; page++ {
-		result, err := c.Incidents.List(ctx, page, 100, client.IncidentListOptions{
-			TeamID:    teams[0].Id,
+		result, err := c.Playbooks.List(ctx, teams[0].Id, page, 100, client.PlaybookListOptions{
 			Sort:      client.SortByCreateAt,
 			Direction: client.SortDesc,
 		})
@@ -62,13 +61,13 @@ func ExampleIncidentsService_List() {
 			log.Fatal(err)
 		}
 
-		incidents = append(incidents, result.Items...)
+		playbooks = append(playbooks, result.Items...)
 		if !result.HasMore {
 			break
 		}
 	}
 
-	for _, incident := range incidents {
-		fmt.Printf("Incident Name: %s\n", incident.Name)
+	for _, playbook := range playbooks {
+		fmt.Printf("Playbook Name: %s\n", playbook.Title)
 	}
 }

--- a/server/api/api_test.go
+++ b/server/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	icClient "github.com/mattermost/mattermost-plugin-incident-collaboration/client"
 	mock_config "github.com/mattermost/mattermost-plugin-incident-collaboration/server/config/mocks"
 	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/incident"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/playbook"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,7 @@ func requireErrorWithStatusCode(t *testing.T, err error, statusCode int) {
 	require.Error(t, err)
 
 	var errResponse *icClient.ErrorResponse
-	require.True(t, errors.As(err, &errResponse))
+	require.Truef(t, errors.As(err, &errResponse), "err is not an instance of errResponse: %s", err.Error())
 	require.Equal(t, statusCode, errResponse.StatusCode)
 }
 
@@ -85,4 +86,50 @@ func toInternalIncidentMetadata(apiIncidentMetadata icClient.IncidentMetadata) i
 	}
 
 	return internalIncidentMetadata
+}
+
+func toAPIPlaybook(internalPlaybook playbook.Playbook) icClient.Playbook {
+	var apiPlaybook icClient.Playbook
+
+	playbookBytes, _ := json.Marshal(internalPlaybook)
+	err := json.Unmarshal(playbookBytes, &apiPlaybook)
+	if err != nil {
+		panic(err)
+	}
+
+	return apiPlaybook
+}
+
+func toAPIPlaybooks(internalPlaybooks []playbook.Playbook) []icClient.Playbook {
+	apiPlaybooks := []icClient.Playbook{}
+
+	for _, internalPlaybook := range internalPlaybooks {
+		apiPlaybooks = append(apiPlaybooks, toAPIPlaybook(internalPlaybook))
+	}
+
+	return apiPlaybooks
+}
+
+func toInternalPlaybook(apiPlaybook icClient.Playbook) playbook.Playbook {
+	var internalPlaybook playbook.Playbook
+
+	playbookBytes, _ := json.Marshal(apiPlaybook)
+	err := json.Unmarshal(playbookBytes, &internalPlaybook)
+	if err != nil {
+		panic(err)
+	}
+
+	return internalPlaybook
+}
+
+func toAPIChecklists(internalChecklists []playbook.Checklist) []icClient.Checklist {
+	var apiChecklists []icClient.Checklist
+
+	checklistBytes, _ := json.Marshal(internalChecklists)
+	err := json.Unmarshal(checklistBytes, &apiChecklists)
+	if err != nil {
+		panic(err)
+	}
+
+	return apiChecklists
 }

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -1137,7 +1137,7 @@ func TestIncidents(t *testing.T) {
 		}
 		incidentService.EXPECT().GetIncidents(gomock.Any(), gomock.Any()).Return(result, nil)
 
-		actualList, err := c.Incidents.List(context.TODO(), icClient.IncidentListOptions{
+		actualList, err := c.Incidents.List(context.TODO(), 0, 200, icClient.IncidentListOptions{
 			TeamID: "testTeamID1",
 		})
 		require.NoError(t, err)
@@ -1156,7 +1156,7 @@ func TestIncidents(t *testing.T) {
 
 		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_VIEW_TEAM).Return(false)
 
-		resultIncident, err := c.Incidents.List(context.TODO(), icClient.IncidentListOptions{
+		resultIncident, err := c.Incidents.List(context.TODO(), 0, 100, icClient.IncidentListOptions{
 			TeamID: "non-existent",
 		})
 		requireErrorWithStatusCode(t, err, http.StatusForbidden)


### PR DESCRIPTION
#### Summary
Introduce the playbooks service to the Go client. Make `page` and `perPage` parameters required when listing, even for incidents, otherwise the results are generally unexpected or mistakenly wrong when the client author forgets to paginate.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-26944