### PR TITLE
MM-34614 Prevent command box from grabbing focus when already opened.

### DIFF
--- a/webapp/src/components/checklist_item_input.tsx
+++ b/webapp/src/components/checklist_item_input.tsx
@@ -21,6 +21,7 @@ const SlashCommandContainer = styled.div`
 
 export const ChecklistItemCommand: FC<ChecklistItemCommandProps> = (props: ChecklistItemCommandProps) => {
     const [commandOpen, setCommandOpen] = useState(props.command.length > 0);
+    const [wasOpened, setWasOpened] = useState(false);
 
     const setCommand = (command: string) => {
         if (command === '') {
@@ -32,6 +33,7 @@ export const ChecklistItemCommand: FC<ChecklistItemCommandProps> = (props: Check
     let slashCommandBox = (
         <TertiaryButton
             onClick={() => {
+                setWasOpened(true);
                 setCommandOpen(true);
             }}
         >
@@ -46,7 +48,7 @@ export const ChecklistItemCommand: FC<ChecklistItemCommandProps> = (props: Check
                 command={props.command === '' ? '/' : props.command}
                 setCommand={setCommand}
                 autocompleteOnBottom={props.autocompleteOnBottom}
-                grabFocus={true}
+                grabFocus={wasOpened}
             />
         );
     }


### PR DESCRIPTION
#### Summary
Fixes the random scrolling issue on the playbook edit screen by preventing the command box from grabbing focus if it's opened already. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34614

