### PR TITLE
MM-34772: Fix broadcast status update

### DIFF
--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -526,7 +526,7 @@ func (s *ServiceImpl) RemoveTimelineEvent(incidentID, eventID string) error {
 	return nil
 }
 
-func (s *ServiceImpl) broadcastStatusUpdate(statusUpdate string, theIncident *Incident, authorID, originalPostID string) error {
+func (s *ServiceImpl) broadcastStatusUpdate(statusUpdate string, theIncident *Incident, newStatus, authorID, originalPostID string) error {
 	incidentChannel, err := s.pluginAPI.Channel.Get(theIncident.ChannelID)
 	if err != nil {
 		return err
@@ -597,7 +597,7 @@ func (s *ServiceImpl) UpdateStatus(incidentID, userID string, options StatusUpda
 		return errors.Wrap(err, "failed to write status post to store. There is now inconsistent state.")
 	}
 
-	if err2 := s.broadcastStatusUpdate(options.Message, incidentToModify, userID, post.Id); err2 != nil {
+	if err2 := s.broadcastStatusUpdate(options.Message, incidentToModify, options.Status, userID, post.Id); err2 != nil {
 		s.pluginAPI.Log.Warn("failed to broadcast the status update to channel", "ChannelID", incidentToModify.BroadcastChannelID)
 	}
 

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -526,7 +526,7 @@ func (s *ServiceImpl) RemoveTimelineEvent(incidentID, eventID string) error {
 	return nil
 }
 
-func (s *ServiceImpl) broadcastStatusUpdate(statusUpdate string, theIncident *Incident, newStatus, authorID, originalPostID string) error {
+func (s *ServiceImpl) broadcastStatusUpdate(statusUpdate string, theIncident *Incident, authorID, originalPostID string) error {
 	incidentChannel, err := s.pluginAPI.Channel.Get(theIncident.ChannelID)
 	if err != nil {
 		return err
@@ -564,6 +564,7 @@ func (s *ServiceImpl) UpdateStatus(incidentID, userID string, options StatusUpda
 	}
 
 	previousStatus := incidentToModify.CurrentStatus
+	incidentToModify.CurrentStatus = options.Status
 
 	post := model.Post{
 		Message:   options.Message,
@@ -597,7 +598,7 @@ func (s *ServiceImpl) UpdateStatus(incidentID, userID string, options StatusUpda
 		return errors.Wrap(err, "failed to write status post to store. There is now inconsistent state.")
 	}
 
-	if err2 := s.broadcastStatusUpdate(options.Message, incidentToModify, options.Status, userID, post.Id); err2 != nil {
+	if err2 := s.broadcastStatusUpdate(options.Message, incidentToModify, userID, post.Id); err2 != nil {
 		s.pluginAPI.Log.Warn("failed to broadcast the status update to channel", "ChannelID", incidentToModify.BroadcastChannelID)
 	}
 

--- a/tests-e2e/cypress/integration/frontstage/incident_broadcast_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_broadcast_spec.js
@@ -93,7 +93,7 @@ describe('incident broadcast', () => {
 
         // # Update the incident's status
         const updateMessage = 'Update - ' + now;
-        cy.updateStatus(updateMessage);
+        cy.updateStatus(updateMessage, 0, 'Active');
 
         // * Verify that the RHS shows the status update
         cy.get('div[class^=UpdateSection-]').within(() => {
@@ -106,7 +106,7 @@ describe('incident broadcast', () => {
         // * Verify that the last post contains the expected header and the update message verbatim
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#postMessageText_${lastPostId}`).contains(`Incident Update: ${incidentName}`);
-            cy.get(`#postMessageText_${lastPostId}`).contains('By @user-1 | Duration: < 1m | Status: Reported');
+            cy.get(`#postMessageText_${lastPostId}`).contains('By @user-1 | Duration: < 1m | Status: Active');
             cy.get(`#postMessageText_${lastPostId}`).contains(updateMessage);
         });
     });

--- a/tests-e2e/cypress/integration/frontstage/incident_broadcast_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/incident_broadcast_spec.js
@@ -128,7 +128,7 @@ describe('incident broadcast', () => {
 
         // # Update the incident's status
         const updateMessage = 'Update - ' + now;
-        cy.updateStatus(updateMessage);
+        cy.updateStatus(updateMessage, 0, 'Active');
 
         // * Verify that the RHS shows the status update
         cy.get('div[class^=UpdateSection-]').within(() => {
@@ -141,7 +141,7 @@ describe('incident broadcast', () => {
         // * Verify that the last post contains the expected header and the update message verbatim
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#postMessageText_${lastPostId}`).contains(`Incident Update: ${incidentName}`);
-            cy.get(`#postMessageText_${lastPostId}`).contains('By @user-1 | Duration: < 1m | Status: Reported');
+            cy.get(`#postMessageText_${lastPostId}`).contains('By @user-1 | Duration: < 1m | Status: Active');
             cy.get(`#postMessageText_${lastPostId}`).contains(updateMessage);
         });
     });

--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -123,8 +123,8 @@ Cypress.Commands.add('createPlaybook', (teamName, playbookName) => {
 // Select the playbook from the dropdown menu
 Cypress.Commands.add('selectPlaybookFromDropdown', (playbookName) => {
     cy.findByTestId('autoCompleteSelector').should('exist').within(() => {
-        cy.get('input').click().type(playbookName);
-        cy.get('#suggestionList').contains(playbookName).click({force: true});
+        cy.get('input').click().type(playbookName.toLowerCase());
+        cy.get('#suggestionList').contains(playbookName).click({ force: true });
     });
 });
 

--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -152,8 +152,10 @@ Cypress.Commands.add('updateStatus', (message, reminder, status) => {
 
         let actualStatus = status;
         if (!actualStatus) {
-            actualStatus = 'Reported';
+            actualStatus = 'reported';
         }
+
+        actualStatus = actualStatus.toLowerCase();
 
         cy.findAllByTestId('autoCompleteSelector').eq(0).within(() => {
             cy.get('input').type(actualStatus, {delay: 200}).type('{enter}');


### PR DESCRIPTION
#### Summary
We were using the previous status when broadcasting a status update. Which was obviously wrong.

I also adapted the specific E2E test, which was not changing the status itself, so the important part was left unchecked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34772

