### PR TITLE
Temporarily hide the /stats page

### DIFF
--- a/tests-e2e/cypress/integration/backstage/backstage_spec.js
+++ b/tests-e2e/cypress/integration/backstage/backstage_spec.js
@@ -42,17 +42,17 @@ describe('backstage', () => {
         cy.visit('/ad-1/');
     });
 
-    it('opens playbooks list view by default', () => {
-        // # Open the backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+    // it('opens statistics view by default', () => {
+    //     // # Open the backstage
+    //     cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
 
-        // * Verify that when backstage loads, the heading is visible and contains "Incident"
-        cy.findByTestId('titleStats').should('exist').contains('Statistics');
-    });
+    //     // * Verify that when backstage loads, the heading is visible and contains "Statistics"
+    //     cy.findByTestId('titleStats').should('exist').contains('Statistics');
+    // });
 
     it('switches to playbooks list view via header button', () => {
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();
@@ -63,7 +63,7 @@ describe('backstage', () => {
 
     it('switches to incidents list view via header button', () => {
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();

--- a/tests-e2e/cypress/integration/backstage/incident_list_spec.js
+++ b/tests-e2e/cypress/integration/backstage/incident_list_spec.js
@@ -84,7 +84,7 @@ describe('backstage incident list', () => {
 
     it('shows welcome page when no incidents', () => {
         // # Open backstage
-        cy.visit(`/${newTeam.name}/com.mattermost.plugin-incident-management/stats`);
+        cy.visit(`/${newTeam.name}/com.mattermost.plugin-incident-management`);
 
         // # Switch to incidents backstage
         cy.findByTestId('incidentsLHSButton').click();
@@ -152,7 +152,7 @@ describe('backstage incident list', () => {
         });
 
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to incidents backstage
         cy.findByTestId('incidentsLHSButton').click();
@@ -174,7 +174,7 @@ describe('backstage incident list', () => {
         });
 
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to incidents backstage
         cy.findByTestId('incidentsLHSButton').click();
@@ -213,7 +213,7 @@ describe('backstage incident list', () => {
             cy.apiLogin('user-1');
 
             // # Open backstage
-            cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+            cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
             // # Switch to incidents backstage
             cy.findByTestId('incidentsLHSButton').click();

--- a/tests-e2e/cypress/integration/backstage/playbook_creation_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_creation_spec.js
@@ -40,7 +40,7 @@ describe('playbook creation button', () => {
         const playbookName = 'Untitled Playbook';
 
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();
@@ -57,7 +57,7 @@ describe('playbook creation button', () => {
         const playbookName = 'Untitled Playbook';
 
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();
@@ -74,7 +74,7 @@ describe('playbook creation button', () => {
         const playbookName = 'Incident Collaboration Playbook';
 
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();
@@ -91,7 +91,7 @@ describe('playbook creation button', () => {
 
     it('shows remove beside members when > 1 member', () => {
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();

--- a/tests-e2e/cypress/integration/backstage/playbook_list_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_list_spec.js
@@ -35,7 +35,7 @@ describe('backstage playbook list', () => {
 
     it('has "Playbooks" and team name in heading', () => {
         // # Open backstage
-        cy.visit('/ad-1/com.mattermost.plugin-incident-management/stats');
+        cy.visit('/ad-1/com.mattermost.plugin-incident-management');
 
         // # Switch to Playbooks backstage
         cy.findByTestId('playbooksLHSButton').click();

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -126,6 +126,8 @@ const Backstage: FC = () => {
         navigateToTeamPluginUrl(currentTeam.name, '/playbooks');
     };
 
+    const experimentalFeaturesEnabled = false;
+
     return (
         <BackstageContainer>
             <Switch>
@@ -134,16 +136,18 @@ const Backstage: FC = () => {
                 <Route>
                     <BackstageNavbar className='flex justify-content-between'>
                         <div className='d-flex items-center'>
-                            <BackstageTitlebarItem
-                                to={`${match.url}/stats`}
-                                activeClassName={'active'}
-                                data-testid='statsLHSButton'
-                            >
-                                <span className='mr-3 d-flex items-center'>
-                                    <div className={'fa fa-line-chart'}/>
-                                </span>
-                                {'Stats'}
-                            </BackstageTitlebarItem>
+                            {experimentalFeaturesEnabled &&
+                                <BackstageTitlebarItem
+                                    to={`${match.url}/stats`}
+                                    activeClassName={'active'}
+                                    data-testid='statsLHSButton'
+                                >
+                                    <span className='mr-3 d-flex items-center'>
+                                        <div className={'fa fa-line-chart'}/>
+                                    </span>
+                                    {'Stats'}
+                                </BackstageTitlebarItem>
+                            }
                             <BackstageTitlebarItem
                                 to={`${match.url}/incidents`}
                                 activeClassName={'active'}
@@ -201,6 +205,12 @@ const Backstage: FC = () => {
                     </Route>
                     <Route path={`${match.url}/stats`}>
                         <StatsView/>
+                    </Route>
+                    <Route
+                        exact={true}
+                        path={`${match.url}`}
+                    >
+                        <Redirect to={`${match.url}/incidents`}/>
                     </Route>
                     <Route>
                         <Redirect to={teamPluginErrorUrl(currentTeam.name, ErrorPageTypes.DEFAULT)}/>

--- a/webapp/src/make_update_main_menu.ts
+++ b/webapp/src/make_update_main_menu.ts
@@ -13,6 +13,8 @@ import {isE20LicensedOrDevelopment} from './license';
 
 import {navigateToTeamPluginUrl} from './browser_routing';
 
+const experimentalFeaturesEnabled = false;
+
 export function makeUpdateMainMenu(registry: PluginRegistry, store: Store<GlobalState>): () => Promise<void> {
     let mainMenuActionId: string | null;
 
@@ -30,7 +32,11 @@ export function makeUpdateMainMenu(registry: PluginRegistry, store: Store<Global
                 'Incident Collaboration',
                 () => {
                     const team = getCurrentTeam(store.getState());
-                    navigateToTeamPluginUrl(team.name, '/stats');
+                    if (experimentalFeaturesEnabled) {
+                        navigateToTeamPluginUrl(team.name, '/stats');
+                    } else {
+                        navigateToTeamPluginUrl(team.name, '/incidents');
+                    }
                 },
             );
         }


### PR DESCRIPTION
#### Summary
We're planning on putting the stats page behind an experimental feature flag, but no time for that in v1.9, so just effectively hide navigation to it for now.

#### Ticket Link
None.