### PR TITLE
MM-35293 - Fix for empty channel members header

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_backstage/overview/participants.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/overview/participants.tsx
@@ -57,13 +57,18 @@ const Participants = (props: Props) => {
                 />
                 <Heading>{'Reporter'}</Heading>
                 <Participant userId={props.incident.reporter_user_id}/>
-                <Heading>{'Channel Members'}</Heading>
-                {profilesExceptTwoMains.map((o) => (
-                    <Participant
-                        key={o.id}
-                        userId={o.id}
-                    />
-                ))}
+                {
+                    profilesExceptTwoMains.length > 0 &&
+                    <>
+                        <Heading>{'Channel Members'}</Heading>
+                        {profilesExceptTwoMains.map((o) => (
+                            <Participant
+                                key={o.id}
+                                userId={o.id}
+                            />
+                        ))}
+                    </>
+                }
             </StyledContent>
         </TabPageContainer>
     );


### PR DESCRIPTION
#### Summary
- Don't show the channel members section if there are no other participants

Looks like:
![image](https://user-images.githubusercontent.com/1490756/116560040-ff024400-a8ce-11eb-9a09-3fcaad538b33.png)


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35293