### PR TITLE
MM-35296 - Fix description bugs

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -386,6 +386,7 @@ func (h *IncidentHandler) createIncident(newIncident incident.Incident, userID s
 	}
 
 	public := true
+	var thePlaybook *playbook.Playbook
 	if newIncident.PlaybookID != "" {
 		pb, err := h.playbookService.Get(newIncident.PlaybookID)
 		if err != nil {
@@ -422,6 +423,8 @@ func (h *IncidentHandler) createIncident(newIncident incident.Incident, userID s
 		if pb.WebhookOnCreationEnabled {
 			newIncident.WebhookOnCreationURL = pb.WebhookOnCreationURL
 		}
+
+		thePlaybook = &pb
 	}
 
 	permission := model.PERMISSION_CREATE_PRIVATE_CHANNEL
@@ -443,7 +446,7 @@ func (h *IncidentHandler) createIncident(newIncident incident.Incident, userID s
 			return nil, errors.New("user is not a member of the channel containing the incident's original post")
 		}
 	}
-	return h.incidentService.CreateIncident(&newIncident, userID, public)
+	return h.incidentService.CreateIncident(&newIncident, thePlaybook, userID, public)
 }
 
 func (h *IncidentHandler) getRequesterInfo(userID string) (permissions.RequesterInfo, error) {

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -214,7 +214,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		poster.EXPECT().PublishWebsocketEventToUser(gomock.Any(), gomock.Any(), gomock.Any())
 		poster.EXPECT().EphemeralPost(gomock.Any(), gomock.Any(), gomock.Any())
-		incidentService.EXPECT().CreateIncident(&i, "testUserID", true).Return(retI, nil)
+		incidentService.EXPECT().CreateIncident(&i, &withid, "testUserID", true).Return(retI, nil)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
@@ -275,7 +275,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
 		poster.EXPECT().PublishWebsocketEventToUser(gomock.Any(), gomock.Any(), gomock.Any())
 		poster.EXPECT().EphemeralPost(gomock.Any(), gomock.Any(), gomock.Any())
-		incidentService.EXPECT().CreateIncident(&i, "testUserID", true).Return(&retI, nil)
+		incidentService.EXPECT().CreateIncident(&i, &withid, "testUserID", true).Return(&retI, nil)
 
 		testrecorder := httptest.NewRecorder()
 		testreq, err := http.NewRequest("POST", "/api/v0/incidents/dialog", bytes.NewBuffer(dialogRequest.ToJson()))
@@ -644,7 +644,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
-		incidentService.EXPECT().CreateIncident(&testIncident, "testUserID", true).Return(&retI, nil)
+		incidentService.EXPECT().CreateIncident(&testIncident, &testPlaybook, "testUserID", true).Return(&retI, nil)
 
 		// Verify that the websocket event is published
 		poster.EXPECT().
@@ -699,7 +699,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
-		incidentService.EXPECT().CreateIncident(&testIncident, "testUserID", true).Return(&retI, nil)
+		incidentService.EXPECT().CreateIncident(&testIncident, &testPlaybook, "testUserID", true).Return(&retI, nil)
 
 		// Verify that the websocket event is published
 		poster.EXPECT().
@@ -732,7 +732,7 @@ func TestIncidents(t *testing.T) {
 		pluginAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_CREATE_PUBLIC_CHANNEL).Return(true)
 		pluginAPI.On("HasPermissionToTeam", "testUserID", "testTeamID", model.PERMISSION_VIEW_TEAM).Return(true)
-		incidentService.EXPECT().CreateIncident(&testIncident, "testUserID", true).Return(&retI, nil)
+		incidentService.EXPECT().CreateIncident(&testIncident, nil, "testUserID", true).Return(&retI, nil)
 
 		// Verify that the websocket event is published
 		poster.EXPECT().

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -969,7 +969,7 @@ And... yes, of course, we have emojis
 		PlaybookID:         gotplaybook.ID,
 		Checklists:         gotplaybook.Checklists,
 		BroadcastChannelID: gotplaybook.BroadcastChannelID,
-	}, r.args.UserId, true)
+	}, &gotplaybook, r.args.UserId, true)
 	if err != nil {
 		r.postCommandResponse("Unable to create test incident: " + err.Error())
 		return
@@ -1096,7 +1096,7 @@ func (r *Runner) actionTestCreate(params []string) {
 		Checklists:      thePlaybook.Checklists,
 	}
 
-	newIncident, err := r.incidentService.CreateIncident(theIncident, r.args.UserId, true)
+	newIncident, err := r.incidentService.CreateIncident(theIncident, &thePlaybook, r.args.UserId, true)
 	if err != nil {
 		r.warnUserAndLogErrorf("unable to create incident: %v", err)
 		return
@@ -1325,7 +1325,7 @@ func (r *Runner) generateTestData(numActiveIncidents, numEndedIncidents int, beg
 			Checklists:      thePlaybook.Checklists,
 		}
 
-		newIncident, err := r.incidentService.CreateIncident(theIncident, r.args.UserId, true)
+		newIncident, err := r.incidentService.CreateIncident(theIncident, &thePlaybook, r.args.UserId, true)
 		if err != nil {
 			r.warnUserAndLogErrorf("Error creating incident: %v", err)
 			return

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -265,7 +265,7 @@ type Service interface {
 	GetIncidents(requesterInfo permissions.RequesterInfo, options FilterOptions) (*GetIncidentsResults, error)
 
 	// CreateIncident creates a new incident. userID is the user who initiated the CreateIncident.
-	CreateIncident(incdnt *Incident, userID string, public bool) (*Incident, error)
+	CreateIncident(incdnt *Incident, playbook *playbook.Playbook, userID string, public bool) (*Incident, error)
 
 	// OpenCreateIncidentDialog opens an interactive dialog to start a new incident.
 	OpenCreateIncidentDialog(teamID, commanderID, triggerID, postID, clientID string, playbooks []playbook.Playbook, isMobileApp bool) error
@@ -373,7 +373,7 @@ type Store interface {
 	// GetIncidents returns filtered incidents and the total count before paging.
 	GetIncidents(requesterInfo permissions.RequesterInfo, options FilterOptions) (*GetIncidentsResults, error)
 
-	// CreateIncident creates a new incident.
+	// CreateIncident creates a new incident. If newIncident has an ID, that ID will be used.
 	CreateIncident(incdnt *Incident) (*Incident, error)
 
 	// UpdateIncident updates an incident.

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -373,7 +373,7 @@ type Store interface {
 	// GetIncidents returns filtered incidents and the total count before paging.
 	GetIncidents(requesterInfo permissions.RequesterInfo, options FilterOptions) (*GetIncidentsResults, error)
 
-	// CreateIncident creates a new incident. If newIncident has an ID, that ID will be used.
+	// CreateIncident creates a new incident. If incdnt has an ID, that ID will be used.
 	CreateIncident(incdnt *Incident) (*Incident, error)
 
 	// UpdateIncident updates an incident.

--- a/server/incident/mocks/mock_service.go
+++ b/server/incident/mocks/mock_service.go
@@ -94,18 +94,18 @@ func (mr *MockServiceMockRecorder) ChangeCreationDate(arg0, arg1 interface{}) *g
 }
 
 // CreateIncident mocks base method
-func (m *MockService) CreateIncident(arg0 *incident.Incident, arg1 string, arg2 bool) (*incident.Incident, error) {
+func (m *MockService) CreateIncident(arg0 *incident.Incident, arg1 *playbook.Playbook, arg2 string, arg3 bool) (*incident.Incident, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateIncident", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateIncident", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*incident.Incident)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateIncident indicates an expected call of CreateIncident
-func (mr *MockServiceMockRecorder) CreateIncident(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) CreateIncident(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIncident", reflect.TypeOf((*MockService)(nil).CreateIncident), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIncident", reflect.TypeOf((*MockService)(nil).CreateIncident), arg0, arg1, arg2, arg3)
 }
 
 // EditChecklistItem mocks base method

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -108,9 +108,6 @@ func (s *ServiceImpl) broadcastIncidentCreation(theIncident *Incident, commander
 
 	announcementMsg := fmt.Sprintf("#### New Incident: ~%s\n", incidentChannel.Name)
 	announcementMsg += fmt.Sprintf("**Commander**: @%s\n", commander.Username)
-	if theIncident.Description != "" {
-		announcementMsg += fmt.Sprintf("**Description**: %s\n", theIncident.Description)
-	}
 
 	if _, err := s.poster.PostMessage(theIncident.AnnouncementChannelID, announcementMsg); err != nil {
 		return err
@@ -1316,12 +1313,6 @@ func (s *ServiceImpl) hasPermissionToModifyIncident(incident *Incident, userID s
 }
 
 func (s *ServiceImpl) createIncidentChannel(incdnt *Incident, public bool) (*model.Channel, error) {
-	channelHeader := "The channel was created by the Incident Collaboration plugin."
-
-	if incdnt.Description != "" {
-		channelHeader = incdnt.Description
-	}
-
 	channelType := model.CHANNEL_PRIVATE
 	if public {
 		channelType = model.CHANNEL_OPEN
@@ -1332,7 +1323,7 @@ func (s *ServiceImpl) createIncidentChannel(incdnt *Incident, public bool) (*mod
 		Type:        channelType,
 		DisplayName: incdnt.Name,
 		Name:        cleanChannelName(incdnt.Name),
-		Header:      channelHeader,
+		Header:      "The channel was created by the Incident Collaboration plugin.",
 	}
 
 	if channel.Name == "" {

--- a/server/incident/service_test.go
+++ b/server/incident/service_test.go
@@ -47,10 +47,14 @@ func TestCreateIncident(t *testing.T) {
 
 		store.EXPECT().CreateIncident(gomock.Any()).Return(incdnt, nil)
 		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "model.channel.is_valid.display_name.app_error"})
+		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
+		mattermostConfig := &model.Config{}
+		mattermostConfig.SetDefaults()
+		pluginAPI.On("GetConfig").Return(mattermostConfig)
 
 		s := incident.NewService(client, store, poster, logger, configService, scheduler, telemetryService)
 
-		_, err := s.CreateIncident(incdnt, "testUserID", true)
+		_, err := s.CreateIncident(incdnt, nil, "testUserID", true)
 		require.Equal(t, err, incident.ErrChannelDisplayNameInvalid)
 	})
 
@@ -72,11 +76,15 @@ func TestCreateIncident(t *testing.T) {
 		}
 
 		store.EXPECT().CreateIncident(gomock.Any()).Return(incdnt, nil)
+		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
+		mattermostConfig := &model.Config{}
+		mattermostConfig.SetDefaults()
+		pluginAPI.On("GetConfig").Return(mattermostConfig)
 		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "model.channel.is_valid.2_or_more.app_error"})
 
 		s := incident.NewService(client, store, poster, logger, configService, scheduler, telemetryService)
 
-		_, err := s.CreateIncident(incdnt, "testUserID", true)
+		_, err := s.CreateIncident(incdnt, nil, "testUserID", true)
 		require.Equal(t, err, incident.ErrChannelDisplayNameInvalid)
 	})
 
@@ -110,6 +118,7 @@ func TestCreateIncident(t *testing.T) {
 		mattermostConfig := &model.Config{}
 		mattermostConfig.SetDefaults()
 		pluginAPI.On("GetConfig").Return(mattermostConfig)
+		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
 		pluginAPI.On("CreateChannel", mock.Anything).Return(&model.Channel{Id: "channel_id"}, nil)
 		pluginAPI.On("AddUserToChannel", "channel_id", "user_id", "bot_user_id").Return(nil, nil)
 		pluginAPI.On("UpdateChannelMemberRoles", "channel_id", "user_id", fmt.Sprintf("%s %s", model.CHANNEL_ADMIN_ROLE_ID, model.CHANNEL_USER_ROLE_ID)).Return(nil, nil)
@@ -122,7 +131,7 @@ func TestCreateIncident(t *testing.T) {
 
 		s := incident.NewService(client, store, poster, logger, configService, scheduler, telemetryService)
 
-		_, err := s.CreateIncident(incdnt, "user_id", true)
+		_, err := s.CreateIncident(incdnt, nil, "user_id", true)
 		require.NoError(t, err)
 	})
 
@@ -145,11 +154,15 @@ func TestCreateIncident(t *testing.T) {
 		}
 
 		store.EXPECT().CreateIncident(gomock.Any()).Return(incdnt, nil)
+		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
+		mattermostConfig := &model.Config{}
+		mattermostConfig.SetDefaults()
+		pluginAPI.On("GetConfig").Return(mattermostConfig)
 		pluginAPI.On("CreateChannel", mock.Anything).Return(nil, &model.AppError{Id: "store.sql_channel.save_channel.exists.app_error"})
 
 		s := incident.NewService(client, store, poster, logger, configService, scheduler, telemetryService)
 
-		_, err := s.CreateIncident(incdnt, "user_id", true)
+		_, err := s.CreateIncident(incdnt, nil, "user_id", true)
 		require.EqualError(t, err, "failed to create incident channel: : , ")
 	})
 
@@ -176,6 +189,7 @@ func TestCreateIncident(t *testing.T) {
 		mattermostConfig := &model.Config{}
 		mattermostConfig.SetDefaults()
 		pluginAPI.On("GetConfig").Return(mattermostConfig)
+		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
 		pluginAPI.On("CreateChannel", mock.Anything).Return(&model.Channel{Id: "channel_id"}, nil)
 		pluginAPI.On("AddUserToChannel", "channel_id", "user_id", "bot_user_id").Return(nil, nil)
 		pluginAPI.On("UpdateChannelMemberRoles", "channel_id", "user_id", fmt.Sprintf("%s %s", model.CHANNEL_ADMIN_ROLE_ID, model.CHANNEL_USER_ROLE_ID)).Return(nil, &model.AppError{Id: "api.channel.update_channel_member_roles.scheme_role.app_error"})
@@ -189,7 +203,7 @@ func TestCreateIncident(t *testing.T) {
 
 		s := incident.NewService(client, store, poster, logger, configService, scheduler, telemetryService)
 
-		_, err := s.CreateIncident(incdnt, "user_id", true)
+		_, err := s.CreateIncident(incdnt, nil, "user_id", true)
 		require.NoError(t, err)
 	})
 
@@ -216,6 +230,7 @@ func TestCreateIncident(t *testing.T) {
 		mattermostConfig := &model.Config{}
 		mattermostConfig.SetDefaults()
 		pluginAPI.On("GetConfig").Return(mattermostConfig)
+		pluginAPI.On("GetTeam", teamID).Return(&model.Team{Id: teamID, Name: "ad-1"}, nil)
 		pluginAPI.On("CreateChannel", mock.MatchedBy(func(channel *model.Channel) bool {
 			return channel.Name != ""
 		})).Return(&model.Channel{Id: "channel_id"}, nil)
@@ -231,7 +246,7 @@ func TestCreateIncident(t *testing.T) {
 
 		s := incident.NewService(client, store, poster, logger, configService, scheduler, telemetryService)
 
-		_, err := s.CreateIncident(incdnt, "user_id", true)
+		_, err := s.CreateIncident(incdnt, nil, "user_id", true)
 		pluginAPI.AssertExpectations(t)
 		require.NoError(t, err)
 	})
@@ -299,7 +314,7 @@ func TestCreateIncident(t *testing.T) {
 
 		s := incident.NewService(client, store, poster, logger, configService, scheduler, telemetryService)
 
-		createdIncident, err := s.CreateIncident(incdnt, "user_id", true)
+		createdIncident, err := s.CreateIncident(incdnt, nil, "user_id", true)
 		require.NoError(t, err)
 
 		select {
@@ -309,7 +324,7 @@ func TestCreateIncident(t *testing.T) {
 				"http://example.com/ad-1/channels/incident-channel-name",
 				payload.ChannelURL)
 			require.Equal(t,
-				"http://example.com/ad-1/com.mattermost.plugin-incident-management/incidents/incidentID",
+				"http://example.com/ad-1/com.mattermost.plugin-incident-management/incidents/"+createdIncident.ID,
 				payload.DetailsURL)
 
 		case <-time.After(time.Second * 5):

--- a/server/sqlstore/incident.go
+++ b/server/sqlstore/incident.go
@@ -211,16 +211,16 @@ func (s *incidentStore) GetIncidents(requesterInfo permissions.RequesterInfo, op
 	}, nil
 }
 
-// CreateIncident creates a new incident.
+// CreateIncident creates a new incident. If newIncident has an ID, that ID will be used.
 func (s *incidentStore) CreateIncident(newIncident *incident.Incident) (out *incident.Incident, err error) {
 	if newIncident == nil {
 		return nil, errors.New("incident is nil")
 	}
-	if newIncident.ID != "" {
-		return nil, errors.New("ID should not be set")
-	}
 	incidentCopy := newIncident.Clone()
-	incidentCopy.ID = model.NewId()
+
+	if incidentCopy.ID == "" {
+		incidentCopy.ID = model.NewId()
+	}
 
 	rawIncident, err := toSQLIncident(*incidentCopy)
 	if err != nil {

--- a/server/sqlstore/incident_test.go
+++ b/server/sqlstore/incident_test.go
@@ -894,11 +894,6 @@ func TestCreateAndGetIncident(t *testing.T) {
 				ExpectedErr: errors.New("incident is nil"),
 			},
 			{
-				Name:        "Incident should not have ID set",
-				Incident:    NewBuilder(t).WithID().ToIncident(),
-				ExpectedErr: errors.New("ID should not be set"),
-			},
-			{
 				Name:        "Incident /can/ contain checklists with no items",
 				Incident:    NewBuilder(t).WithChecklists([]int{0}).ToIncident(),
 				ExpectedErr: nil,


### PR DESCRIPTION
#### Summary
- We don't ask for the description when starting an incident, it is inherited from the playbook. So:
  - Don't put the description in the new incident broadcast message
  - Don't put the description in the channel header

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35296