### PR TITLE
MM-35291 - Fix incident backstage rendering

### DIFF
--- a/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
@@ -24,7 +24,17 @@ import {
 } from 'src/components/backstage/incidents/shared';
 import ExportLink from 'src/components/backstage/incidents/incident_details/export_link';
 
+const OuterContainer = styled.div`
+    background: var(center-channel-bg);
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+`;
+
 const TopContainer = styled.div`
+    position: sticky;
+    z-index: 2;
+    top: 0;
     background: var(--center-channel-bg);
     width: 100%;
 `;
@@ -46,9 +56,9 @@ const SecondRow = styled.div`
 `;
 
 const BottomContainer = styled.div`
+    flex-grow: 1;
     background: rgba(var(--center-channel-color-rgb), 0.03);
     width: 100%;
-    height: 100%;
 `;
 
 const InnerContainer = styled.div`
@@ -151,7 +161,7 @@ const IncidentBackstage = () => {
     const tabPage = <Overview incident={incident}/>;
 
     return (
-        <>
+        <OuterContainer>
             <TopContainer>
                 <FirstRow>
                     <LeftArrow
@@ -180,7 +190,7 @@ const IncidentBackstage = () => {
                     {tabPage}
                 </InnerContainer>
             </BottomContainer>
-        </>
+        </OuterContainer>
     );
 };
 


### PR DESCRIPTION
#### Summary
- Fixed the background rendering (good eye!)
- Discovered that the playbook edit screen is doing something very cool: the navbar (with the save and back buttons) scrolls then sticks to the top, hiding the Incident/Playbooks/Settings, like so:

![image](https://user-images.githubusercontent.com/1490756/116608424-2a058b80-a901-11eb-9c5f-38ecd34c5cd2.png)
![image](https://user-images.githubusercontent.com/1490756/116608457-338ef380-a901-11eb-94f2-e5ff06d50306.png)

- So changing the Incidents page to do the same:

![image](https://user-images.githubusercontent.com/1490756/116608531-4d303b00-a901-11eb-94c9-a5c508dab2da.png)
![image](https://user-images.githubusercontent.com/1490756/116608562-57ead000-a901-11eb-987d-5a76d96862f7.png)


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35291