### PR TITLE
Update license to allow for extended usage

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,7 +17,7 @@ modifications and/or patches may only be used, copied, modified, displayed,
 distributed, or otherwise exploited with a valid license or Subscription for the correct number of 
 Registered Authorized Users of the Software.  Notwithstanding
 the foregoing, you may copy and modify the Software for development and testing
-purposes, without requiring a subscription.  You agree that Mattermost and/or
+purposes, without requiring a valid license or Subscription.  You agree that Mattermost and/or
 its licensors (as applicable) retain all right, title and interest in and to
 all such modifications.  You are not granted any other rights beyond what is
 expressly stated herein.  Subject to the foregoing, it is forbidden to copy,

--- a/LICENSE
+++ b/LICENSE
@@ -5,17 +5,17 @@ With regard to the Mattermost Software:
 
 This software and associated documentation files (the "Software") may only be
 used in production, if you (and any entity that you represent) have agreed to,
-and are in compliance with, the Mattermost Terms of Service, available at
-https://mattermost.com/enterprise-edition-terms/ (the “EE Terms”), or other
-agreement governing the use of the Software, as agreed by you and Mattermost,
-and otherwise have a valid Mattermost Enterprise E20 subscription for the
-correct number of user seats. Subject to the foregoing sentence, you are free
+and are in compliance with all of the following: (a) the Mattermost Terms of Service, available at
+https://mattermost.com/enterprise-edition-terms/ (the “EE Terms”), (b) any other
+agreement(s) governing the use of the Software, as agreed upon by you and Mattermost,
+and (c) you otherwise have a valid license or Subscription for the
+correct number of Registered Authorized Users of the Software. Subject to the foregoing, you are free
 to modify this Software and publish patches to the Software. You agree that
 Mattermost and/or its licensors (as applicable) retain all right, title and
 interest in and to all such modifications and/or patches, and all such
 modifications and/or patches may only be used, copied, modified, displayed,
-distributed, or otherwise exploited with a valid Mattermost Enterprise E20
-Edition subscription for the  correct number of user seats.  Notwithstanding
+distributed, or otherwise exploited with a valid license or Subscription for the correct number of 
+Registered Authorized Users of the Software.  Notwithstanding
 the foregoing, you may copy and modify the Software for development and testing
 purposes, without requiring a subscription.  You agree that Mattermost and/or
 its licensors (as applicable) retain all right, title and interest in and to


### PR DESCRIPTION
Removed specific references to E20 so the tool can be used for limited purposes in other versions of the software.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

