### PR TITLE
MM-35041 MM-35042 Basic retrospective tab and infrastructure

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -92,6 +92,10 @@ func NewIncidentHandler(router *mux.Router, incidentService incident.Service, pl
 	checklistItem.HandleFunc("/assignee", handler.itemSetAssignee).Methods(http.MethodPut)
 	checklistItem.HandleFunc("/run", handler.itemRun).Methods(http.MethodPost)
 
+	retrospectiveRouter := incidentRouterAuthorized.PathPrefix("/retrospective").Subrouter()
+	retrospectiveRouter.HandleFunc("", handler.updateRetrospective).Methods(http.MethodPost)
+	retrospectiveRouter.HandleFunc("/publish", handler.publishRetrospective).Methods(http.MethodPost)
+
 	telemetryRouterAuthorized := router.PathPrefix("/telemetry").Subrouter()
 	telemetryRouterAuthorized.Use(handler.checkViewPermissions)
 	telemetryRouterAuthorized.HandleFunc("/incident/{id:[A-Za-z0-9]+}", handler.telemetryForIncident).Methods(http.MethodPost)
@@ -1247,6 +1251,41 @@ func (h *IncidentHandler) postIncidentCreatedMessage(incdnt *incident.Incident, 
 	h.poster.EphemeralPost(incdnt.CommanderUserID, channelID, post)
 
 	return nil
+}
+
+func (h *IncidentHandler) updateRetrospective(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	incidentID := vars["id"]
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	var retroUpdate struct {
+		Retrospective string `json:"retrospective"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&retroUpdate); err != nil {
+		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode payload", err)
+		return
+	}
+
+	if err := h.incidentService.UpdateRetrospective(incidentID, userID, retroUpdate.Retrospective); err != nil {
+		HandleErrorWithCode(w, http.StatusInternalServerError, "unable to update retrospective", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *IncidentHandler) publishRetrospective(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	incidentID := vars["id"]
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	if err := h.incidentService.PublishRetrospective(incidentID, userID); err != nil {
+		HandleErrorWithCode(w, http.StatusInternalServerError, "unable to publish retrospective", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 // parseIncidentsFilterOptions is only for parsing. Put validation logic in incident.validateOptions.

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -466,10 +466,10 @@ type Telemetry interface {
 	RunTaskSlashCommand(incidentID, userID string)
 
 	// UpdateRetrospective event
-	UpdateRetrospective(incidentID, userID string)
+	UpdateRetrospective(incident *Incident, userID string)
 
 	// PublishRetrospective event
-	PublishRetrospective(incidentID, userID string)
+	PublishRetrospective(incident *Incident, userID string)
 }
 
 type JobOnceScheduler interface {

--- a/server/incident/incident.go
+++ b/server/incident/incident.go
@@ -52,6 +52,7 @@ type Incident struct {
 	DefaultCommanderID      string               `json:"default_commander_id"`
 	AnnouncementChannelID   string               `json:"announcement_channel_id"`
 	WebhookOnCreationURL    string               `json:"webhook_on_creation_url"`
+	Retrospective           string               `json:"retrospective"`
 }
 
 func (i *Incident) Clone() *Incident {
@@ -366,6 +367,12 @@ type Service interface {
 	// UserHasLeftChannel is called when userID has left channelID. If actorID is not blank, userID
 	// was removed from the channel by actorID.
 	UserHasLeftChannel(userID, channelID, actorID string)
+
+	// UpdateRetrospective updates the retrospective for the given incident.
+	UpdateRetrospective(incidentID, userID, newRetrospective string) error
+
+	// PublishRetrospective publishes the retrospective.
+	PublishRetrospective(incidentID, userID string) error
 }
 
 // Store defines the methods the ServiceImpl needs from the interfaceStore.
@@ -457,6 +464,12 @@ type Telemetry interface {
 	// RunTaskSlashCommand tracks the execution of a slash command attached to
 	// a checklist item.
 	RunTaskSlashCommand(incidentID, userID string)
+
+	// UpdateRetrospective event
+	UpdateRetrospective(incidentID, userID string)
+
+	// PublishRetrospective event
+	PublishRetrospective(incidentID, userID string)
 }
 
 type JobOnceScheduler interface {

--- a/server/incident/mocks/mock_service.go
+++ b/server/incident/mocks/mock_service.go
@@ -351,6 +351,20 @@ func (mr *MockServiceMockRecorder) OpenUpdateStatusDialog(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenUpdateStatusDialog", reflect.TypeOf((*MockService)(nil).OpenUpdateStatusDialog), arg0, arg1)
 }
 
+// PublishRetrospective mocks base method
+func (m *MockService) PublishRetrospective(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishRetrospective", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishRetrospective indicates an expected call of PublishRetrospective
+func (mr *MockServiceMockRecorder) PublishRetrospective(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishRetrospective", reflect.TypeOf((*MockService)(nil).PublishRetrospective), arg0, arg1)
+}
+
 // RemoveChecklistItem mocks base method
 func (m *MockService) RemoveChecklistItem(arg0, arg1 string, arg2, arg3 int) error {
 	m.ctrl.T.Helper()
@@ -460,6 +474,20 @@ func (m *MockService) ToggleCheckedState(arg0, arg1 string, arg2, arg3 int) erro
 func (mr *MockServiceMockRecorder) ToggleCheckedState(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToggleCheckedState", reflect.TypeOf((*MockService)(nil).ToggleCheckedState), arg0, arg1, arg2, arg3)
+}
+
+// UpdateRetrospective mocks base method
+func (m *MockService) UpdateRetrospective(arg0, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRetrospective", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateRetrospective indicates an expected call of UpdateRetrospective
+func (mr *MockServiceMockRecorder) UpdateRetrospective(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRetrospective", reflect.TypeOf((*MockService)(nil).UpdateRetrospective), arg0, arg1, arg2)
 }
 
 // UpdateStatus mocks base method

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -1624,6 +1624,31 @@ func (s *ServiceImpl) sendIncidentToClient(incidentID string) error {
 	return nil
 }
 
+func (s *ServiceImpl) UpdateRetrospective(incidentID, updaterID, newRetrospective string) error {
+	incidentToModify, err := s.store.GetIncident(incidentID)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve incident")
+	}
+
+	incidentToModify.Retrospective = newRetrospective
+
+	if err = s.store.UpdateIncident(incidentToModify); err != nil {
+		return errors.Wrap(err, "failed to update incident")
+	}
+
+	s.poster.PublishWebsocketEventToChannel(incidentUpdatedWSEvent, incidentToModify, incidentToModify.ChannelID)
+	s.telemetry.UpdateRetrospective(incidentID, updaterID)
+
+	return nil
+}
+
+func (s *ServiceImpl) PublishRetrospective(incidentID, publisherID string) error {
+	//TODO: Publish the retrospective
+	s.telemetry.PublishRetrospective(incidentID, publisherID)
+
+	return nil
+}
+
 func getUserDisplayName(user *model.User) string {
 	if user == nil {
 		return ""

--- a/server/incident/service.go
+++ b/server/incident/service.go
@@ -1637,14 +1637,19 @@ func (s *ServiceImpl) UpdateRetrospective(incidentID, updaterID, newRetrospectiv
 	}
 
 	s.poster.PublishWebsocketEventToChannel(incidentUpdatedWSEvent, incidentToModify, incidentToModify.ChannelID)
-	s.telemetry.UpdateRetrospective(incidentID, updaterID)
+	s.telemetry.UpdateRetrospective(incidentToModify, updaterID)
 
 	return nil
 }
 
 func (s *ServiceImpl) PublishRetrospective(incidentID, publisherID string) error {
+	incidentToPublish, err := s.store.GetIncident(incidentID)
+	if err != nil {
+		return errors.Wrap(err, "failed to retrieve incident")
+	}
+
 	//TODO: Publish the retrospective
-	s.telemetry.PublishRetrospective(incidentID, publisherID)
+	s.telemetry.PublishRetrospective(incidentToPublish, publisherID)
 
 	return nil
 }

--- a/server/sqlstore/incident.go
+++ b/server/sqlstore/incident.go
@@ -53,7 +53,7 @@ func NewIncidentStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQLSt
 			"i.CreateAt", "i.EndAt", "i.DeleteAt", "i.PostID", "i.PlaybookID", "i.ReporterUserID", "i.CurrentStatus",
 			"i.ChecklistsJSON", "COALESCE(i.ReminderPostID, '') ReminderPostID", "i.PreviousReminder", "i.BroadcastChannelID",
 			"COALESCE(ReminderMessageTemplate, '') ReminderMessageTemplate", "ConcatenatedInvitedUserIDs", "ConcatenatedInvitedGroupIDs", "DefaultCommanderID",
-			"AnnouncementChannelID", "WebhookOnCreationURL").
+			"AnnouncementChannelID", "WebhookOnCreationURL", "Retrospective").
 		From("IR_Incident AS i").
 		Join("Channels AS c ON (c.Id = i.ChannelId)")
 
@@ -253,6 +253,7 @@ func (s *incidentStore) CreateIncident(newIncident *incident.Incident) (out *inc
 			"DefaultCommanderID":          rawIncident.DefaultCommanderID,
 			"AnnouncementChannelID":       rawIncident.AnnouncementChannelID,
 			"WebhookOnCreationURL":        rawIncident.WebhookOnCreationURL,
+			"Retrospective":               rawIncident.Retrospective,
 			// Preserved for backwards compatibility with v1.2
 			"ActiveStage":      0,
 			"ActiveStageTitle": "",
@@ -298,6 +299,7 @@ func (s *incidentStore) UpdateIncident(newIncident *incident.Incident) error {
 			"DefaultCommanderID":          rawIncident.DefaultCommanderID,
 			"AnnouncementChannelID":       rawIncident.AnnouncementChannelID,
 			"WebhookOnCreationURL":        rawIncident.WebhookOnCreationURL,
+			"Retrospective":               rawIncident.Retrospective,
 		}).
 		Where(sq.Eq{"ID": rawIncident.ID}))
 

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -642,4 +642,24 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		fromVersion: semver.MustParse("0.14.0"),
+		toVersion:   semver.MustParse("0.15.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			if e.DriverName() == model.DATABASE_DRIVER_MYSQL {
+				if err := addColumnToMySQLTable(e, "IR_Incident", "Retrospective", "TEXT"); err != nil {
+					return errors.Wrapf(err, "failed adding column Retrospective to table IR_Incident")
+				}
+				if _, err := e.Exec("UPDATE IR_Incident SET Retrospective = '' WHERE Retrospective IS NULL"); err != nil {
+					return errors.Wrapf(err, "failed setting default value in column Retrospective of table IR_Incident")
+				}
+			} else {
+				if err := addColumnToPGTable(e, "IR_Incident", "Retrospective", "TEXT DEFAULT ''"); err != nil {
+					return errors.Wrapf(err, "failed adding column Retrospective to table IR_Incident")
+				}
+			}
+
+			return nil
+		},
+	},
 }

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -85,3 +85,9 @@ func (t *NoopTelemetry) ChangeCommander(*incident.Incident, string) {
 // RunTaskSlashCommand does nothing
 func (t *NoopTelemetry) RunTaskSlashCommand(string, string) {
 }
+
+func (t *NoopTelemetry) UpdateRetrospective(incidentID, userID string) {
+}
+
+func (t *NoopTelemetry) PublishRetrospective(incidentID, userID string) {
+}

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -86,8 +86,8 @@ func (t *NoopTelemetry) ChangeCommander(*incident.Incident, string) {
 func (t *NoopTelemetry) RunTaskSlashCommand(string, string) {
 }
 
-func (t *NoopTelemetry) UpdateRetrospective(incidentID, userID string) {
+func (t *NoopTelemetry) UpdateRetrospective(incident *incident.Incident, userID string) {
 }
 
-func (t *NoopTelemetry) PublishRetrospective(incidentID, userID string) {
+func (t *NoopTelemetry) PublishRetrospective(incident *incident.Incident, userID string) {
 }

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -235,14 +235,14 @@ func (t *RudderTelemetry) RunTaskSlashCommand(incidentID, userID string) {
 	t.track(eventTasks, properties)
 }
 
-func (t *RudderTelemetry) UpdateRetrospective(incidentID, userID string) {
-	properties := taskProperties(incidentID, userID)
+func (t *RudderTelemetry) UpdateRetrospective(incident *incident.Incident, userID string) {
+	properties := incidentProperties(incident, userID)
 	properties["Action"] = actionUpdateRetrospective
 	t.track(eventTasks, properties)
 }
 
-func (t *RudderTelemetry) PublishRetrospective(incidentID, userID string) {
-	properties := taskProperties(incidentID, userID)
+func (t *RudderTelemetry) PublishRetrospective(incident *incident.Incident, userID string) {
+	properties := incidentProperties(incident, userID)
 	properties["Action"] = actionPublishRetrospective
 	t.track(eventTasks, properties)
 }

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -30,6 +30,8 @@ const (
 	actionChangeCommander          = "change_commander"
 	actionUpdateStatus             = "update_status"
 	actionAddTimelineEventFromPost = "add_timeline_event_from_post"
+	actionUpdateRetrospective      = "update_retrospective"
+	actionPublishRetrospective     = "publish_retrospective"
 
 	eventTasks                = "tasks"
 	actionAddTask             = "add_task"
@@ -39,9 +41,6 @@ const (
 	actionMoveTask            = "move_task"
 	actionSetAssigneeForTask  = "set_assignee_for_task"
 	actionRunTaskSlashCommand = "run_task_slash_command"
-
-	actionUpdateRetrospective  = "update_retrospective"
-	actionPublishRetrospective = "publish_retrospective"
 
 	eventPlaybook = "playbook"
 	actionUpdate  = "update"

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -40,6 +40,9 @@ const (
 	actionSetAssigneeForTask  = "set_assignee_for_task"
 	actionRunTaskSlashCommand = "run_task_slash_command"
 
+	actionUpdateRetrospective  = "update_retrospective"
+	actionPublishRetrospective = "publish_retrospective"
+
 	eventPlaybook = "playbook"
 	actionUpdate  = "update"
 	actionDelete  = "delete"
@@ -229,6 +232,18 @@ func (t *RudderTelemetry) MoveTask(incidentID, userID string) {
 func (t *RudderTelemetry) RunTaskSlashCommand(incidentID, userID string) {
 	properties := taskProperties(incidentID, userID)
 	properties["Action"] = actionRunTaskSlashCommand
+	t.track(eventTasks, properties)
+}
+
+func (t *RudderTelemetry) UpdateRetrospective(incidentID, userID string) {
+	properties := taskProperties(incidentID, userID)
+	properties["Action"] = actionUpdateRetrospective
+	t.track(eventTasks, properties)
+}
+
+func (t *RudderTelemetry) PublishRetrospective(incidentID, userID string) {
+	properties := taskProperties(incidentID, userID)
+	properties["Action"] = actionPublishRetrospective
 	t.track(eventTasks, properties)
 }
 

--- a/tests-e2e/cypress/integration/frontstage/rhs/welcome_spec.js
+++ b/tests-e2e/cypress/integration/frontstage/rhs/welcome_spec.js
@@ -101,7 +101,7 @@ describe('incident rhs > welcome', () => {
             });
 
             // # Click the prompt to create an incident
-            cy.get('#rhsContainer').findByText('Start Incident').click();
+            cy.get('#rhsContainer').findByText('Start Incident').click({force: true});
 
             // * Verify the incident creation dialog has opened
             cy.get('#interactiveDialogModal').should('exist').within(() => {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -306,6 +306,15 @@ export async function fetchGlobalSettings(): Promise<GlobalSettings> {
     return globalSettingsSetDefaults(data);
 }
 
+export async function updateRetrospective(incidentID: string, updatedText: string) {
+    const data = await doPost(`${apiUrl}/incidents/${incidentID}/retrospective`,
+        JSON.stringify({
+            retrospective: updatedText,
+        }));
+
+    return data;
+}
+
 export function exportChannelUrl(channelId: string) {
     const exportPluginUrl = '/plugins/com.mattermost.plugin-channel-export/api/v1';
 

--- a/webapp/src/components/assets/buttons.tsx
+++ b/webapp/src/components/assets/buttons.tsx
@@ -18,13 +18,6 @@ export const PrimaryButton = styled.button`
     padding: 0 20px;
     position: relative;
 
-    > span {
-        display: flex;
-        position: relative;
-        z-index: 1;
-        align-items: center;
-    }
-
     &:before {
         content: '';
         left: 0;

--- a/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
@@ -15,6 +15,7 @@ import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 import {Incident, Metadata as IncidentMetadata} from 'src/types/incident';
 import {IncidentBackstageTabState} from 'src/types/backstage';
 import {Overview} from 'src/components/backstage/incidents/incident_backstage/overview/overview';
+import {Retrospective} from 'src/components/backstage/incidents/incident_backstage/retrospective/retrospective';
 import {fetchIncident, fetchIncidentMetadata} from 'src/client';
 import {navigateToTeamPluginUrl, navigateToUrl, teamPluginErrorUrl} from 'src/browser_routing';
 import {ErrorPageTypes} from 'src/constants';
@@ -158,7 +159,10 @@ const IncidentBackstage = () => {
         navigateToTeamPluginUrl(currentTeam.name, '/incidents');
     };
 
-    const tabPage = <Overview incident={incident}/>;
+    let tabPage = <Overview incident={incident}/>;
+    if (tabState === IncidentBackstageTabState.ViewingRetrospective) {
+        tabPage = <Retrospective incident={incident}/>;
+    }
 
     return (
         <OuterContainer>

--- a/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
@@ -24,6 +24,7 @@ import {
     SecondaryButtonLargerRight,
 } from 'src/components/backstage/incidents/shared';
 import ExportLink from 'src/components/backstage/incidents/incident_details/export_link';
+import {useExperimentalFeaturesEnabled} from 'src/hooks';
 
 const OuterContainer = styled.div`
     background: var(center-channel-bg);
@@ -123,6 +124,7 @@ const IncidentBackstage = () => {
     const currentTeam = useSelector<GlobalState, Team>(getCurrentTeam);
     const channel = useSelector<GlobalState, Channel | null>((state) => (incident ? getChannel(state, incident.channel_id) : null));
     const match = useRouteMatch<MatchParams>();
+    const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled();
 
     const [fetchingState, setFetchingState] = useState(FetchingStateType.loading);
 
@@ -187,12 +189,14 @@ const IncidentBackstage = () => {
                     >
                         {'Overview'}
                     </TabItem>
-                    <TabItem
-                        active={tabState === IncidentBackstageTabState.ViewingRetrospective}
-                        onClick={() => setTabState(IncidentBackstageTabState.ViewingRetrospective)}
-                    >
-                        {'Retrospective'}
-                    </TabItem>
+                    {experimentalFeaturesEnabled &&
+                        <TabItem
+                            active={tabState === IncidentBackstageTabState.ViewingRetrospective}
+                            onClick={() => setTabState(IncidentBackstageTabState.ViewingRetrospective)}
+                        >
+                            {'Retrospective'}
+                        </TabItem>
+                    }
                 </SecondRow>
             </TopContainer>
             <BottomContainer>

--- a/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
@@ -187,6 +187,12 @@ const IncidentBackstage = () => {
                     >
                         {'Overview'}
                     </TabItem>
+                    <TabItem
+                        active={tabState === IncidentBackstageTabState.ViewingRetrospective}
+                        onClick={() => setTabState(IncidentBackstageTabState.ViewingRetrospective)}
+                    >
+                        {'Retrospective'}
+                    </TabItem>
                 </SecondRow>
             </TopContainer>
             <BottomContainer>

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/followups.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/followups.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import styled from 'styled-components';
+
+import {Incident, IncidentStatus} from 'src/types/incident';
+import Profile from 'src/components/profile/profile';
+import {Badge, Content, TabPageContainer, Title} from 'src/components/backstage/incidents/shared';
+
+const StyledContent = styled(Content)`
+    margin: 8px 0 0 0;
+`;
+
+const Grid = styled.div`
+    display: grid;
+    grid-template-columns: 3fr 1fr 1fr 1fr;
+    grid-template-rows: 1fr;
+`;
+
+const ColTitle = styled.div`
+    font-weight: 600;
+`;
+
+const Cell = styled.div`
+    padding-top: 8px;
+`;
+
+const SmallProfile = styled(Profile)`
+    > .image {
+        width: 16px;
+        height: 16px;
+    }
+`;
+
+const Line = styled.div`
+    height: 1px;
+    background: grey;
+`;
+
+const Followups = (props: { incident: Incident }) => {
+    return (
+        <TabPageContainer>
+            <Title>{'Follow ups'}</Title>
+            <StyledContent>
+                <Grid>
+                    <ColTitle>{'Description'}</ColTitle>
+                    <ColTitle>{'Owner'}</ColTitle>
+                    <ColTitle>{'Status'}</ColTitle>
+                    <ColTitle>{'Jira issue'}</ColTitle>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+
+                    <Cell>{'Improve our TTR by automating our OgsGenie webhooks.'}</Cell>
+                    <Cell>
+                        <SmallProfile userId={props.incident.commander_user_id}/>
+                    </Cell>
+                    <Cell>
+                        <Badge status={'Open' as IncidentStatus}/>
+                    </Cell>
+                    <Cell>
+                        <a href={''}>{'MM-42843'}</a>
+                    </Cell>
+
+                    <Cell>{'Notify affected customers sooner by collecting related Pagerduty events and DMing commander automatically.'}</Cell>
+                    <Cell>
+                        <SmallProfile userId={props.incident.reporter_user_id}/>
+                    </Cell>
+                    <Cell>
+                        <Badge status={'In Progress' as IncidentStatus}/>
+                    </Cell>
+                    <Cell>
+                        <a href={''}>{'MM-42850'}</a>
+                    </Cell>
+                </Grid>
+            </StyledContent>
+        </TabPageContainer>
+    );
+};
+
+export default Followups;

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/followups.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/followups.tsx
@@ -38,6 +38,7 @@ const Line = styled.div`
     background: grey;
 `;
 
+// STUB COMPONENT. NOT IN ACTIVE USE YET
 const Followups = (props: { incident: Incident }) => {
     return (
         <TabPageContainer>

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/learnings.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/learnings.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import styled from 'styled-components';
+
+import {Incident} from 'src/types/incident';
+import {useProfilesInChannel} from 'src/hooks';
+import ProfileVertical
+    from 'src/components/backstage/incidents/incident_backstage/retrospective/profile_vertical';
+import {
+    Content,
+    SecondaryButtonRight,
+    TabPageContainer,
+    Title,
+} from 'src/components/backstage/incidents/shared';
+
+const Header = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const StyledContent = styled(Content)`
+    padding: 8px;
+`;
+
+const Grid = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 1px 10fr 1px 10fr 1px 10fr;
+    grid-template-rows: auto 1px auto 1px auto 1px auto;
+`;
+
+const Line = styled.div`
+    background: grey;
+`;
+
+const Cell = styled.div`
+    padding: 8px;
+`;
+
+const ColTitle = styled.div`
+    padding: 8px;
+    font-weight: 600;
+`;
+
+const Learnings = (props: {incident: Incident}) => {
+    const profilesInChannel = useProfilesInChannel(props.incident.channel_id);
+    const profilesExceptCommander = profilesInChannel.filter((u) => u.id !== props.incident.commander_user_id);
+    const second = profilesExceptCommander[1];
+    const third = profilesExceptCommander[2];
+
+    return (
+        <TabPageContainer>
+            <Header>
+                <Title>{'Learnings'}</Title>
+                <SecondaryButtonRight>{'Collect Responses'}</SecondaryButtonRight>
+            </Header>
+            <StyledContent>
+                <Grid>
+                    <Cell/>
+                    <Line/>
+                    <ColTitle>{'What went well?'}</ColTitle>
+                    <Line/>
+                    <ColTitle>{'What could have gone better?'}</ColTitle>
+                    <Line/>
+                    <ColTitle>{'What should we do differently next time?'}</ColTitle>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+
+                    <Cell><ProfileVertical userId={props.incident.commander_user_id}/></Cell>
+                    <Line/>
+                    <Cell>{'Sed venenatis massa laoreet ex tristique, quis suscipit ante aliquam. Nulla dignissim, justo vel finibus malesuada, turpis dui hendrerit elit, at ultrices libero libero faucibus odio.'}</Cell>
+                    <Line/>
+                    <Cell>{'Maecenas ac neque sed leo mattis faucibus eget nec ex. Duis pharetra nisi quis nulla sodales auctor.'}</Cell>
+                    <Line/>
+                    <Cell>{'Sed id velit vitae sapien mattis fringilla nec ac neque. Mauris rhoncus pellentesque libero. Nullam vitae magna tortor.'}</Cell>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+
+                    <Cell><ProfileVertical userId={second.id}/></Cell>
+                    <Line/>
+                    <Cell>{'In viverra eros sit amet est tincidunt malesuada.'}</Cell>
+                    <Line/>
+                    <Cell>{'Donec id ipsum in lorem lacinia rhoncus quis id urna. Cras rhoncus faucibus sem eget ornare.'}</Cell>
+                    <Line/>
+                    <Cell>{'Aenean augue magna, consequat eu porttitor vel, fringilla a purus. Proin fermentum lacus at efficitur elementum. Aenean a mollis nunc.'}</Cell>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+                    <Line/>
+
+                    <Cell><ProfileVertical userId={third.id}/></Cell>
+                    <Line/>
+                    <Cell>{'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed mauris dui, imperdiet quis rutrum eget, lobortis a mauris.'}</Cell>
+                    <Line/>
+                    <Cell>{'Morbi vitae consectetur nisl, eu finibus odio. Duis nec finibus elit. Donec magna nisl, aliquam nec odio id, condimentum convallis augue.'}</Cell>
+                    <Line/>
+                    <Cell>{'Vivamus vestibulum nisi ut sapien pharetra, quis elementum enim tincidunt. Nulla et massa egestas, fringilla augue nec, interdum metus.'}</Cell>
+                </Grid>
+            </StyledContent>
+        </TabPageContainer>
+    );
+};
+
+export default Learnings;

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/learnings.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/learnings.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {Incident} from 'src/types/incident';
-import {useProfilesInChannel} from 'src/hooks';
 import ProfileVertical
     from 'src/components/backstage/incidents/incident_backstage/retrospective/profile_vertical';
 import {
@@ -44,11 +43,6 @@ const ColTitle = styled.div`
 `;
 
 const Learnings = (props: {incident: Incident}) => {
-    const profilesInChannel = useProfilesInChannel(props.incident.channel_id);
-    const profilesExceptCommander = profilesInChannel.filter((u) => u.id !== props.incident.commander_user_id);
-    const second = profilesExceptCommander[1];
-    const third = profilesExceptCommander[2];
-
     return (
         <TabPageContainer>
             <Header>
@@ -87,7 +81,7 @@ const Learnings = (props: {incident: Incident}) => {
                     <Line/>
                     <Line/>
 
-                    <Cell><ProfileVertical userId={second.id}/></Cell>
+                    <Cell><ProfileVertical userId={props.incident.commander_user_id}/></Cell>
                     <Line/>
                     <Cell>{'In viverra eros sit amet est tincidunt malesuada.'}</Cell>
                     <Line/>
@@ -102,7 +96,7 @@ const Learnings = (props: {incident: Incident}) => {
                     <Line/>
                     <Line/>
 
-                    <Cell><ProfileVertical userId={third.id}/></Cell>
+                    <Cell><ProfileVertical userId={props.incident.commander_user_id}/></Cell>
                     <Line/>
                     <Cell>{'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed mauris dui, imperdiet quis rutrum eget, lobortis a mauris.'}</Cell>
                     <Line/>

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/learnings.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/learnings.tsx
@@ -42,6 +42,7 @@ const ColTitle = styled.div`
     font-weight: 600;
 `;
 
+// STUB COMPONENT. NOT IN ACTIVE USE YET
 const Learnings = (props: {incident: Incident}) => {
     return (
         <TabPageContainer>

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/profile_vertical.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/profile_vertical.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect} from 'react';
+import {useSelector, useDispatch} from 'react-redux';
+import classNames from 'classnames';
+import styled from 'styled-components';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+import {UserProfile} from 'mattermost-redux/types/users';
+import {displayUsername} from 'mattermost-redux/utils/user_utils';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
+import {getUser as fetchUser} from 'mattermost-redux/actions/users';
+import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+import {Client4} from 'mattermost-redux/client';
+
+interface Props {
+    userId: string;
+}
+
+const Profile = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+`;
+
+const Wrapper = styled.div`
+    padding: 0;
+`;
+
+const Name = styled.div`
+    font-weight: 600;
+`;
+
+const ProfilePic = styled.img`
+    margin: 0;
+    width: 32px;
+    height: 32px;
+    background-color: #bbb;
+    border-radius: 50%;
+    display: inline-block;
+`;
+
+const ProfileVertical = (props: Props) => {
+    const dispatch = useDispatch();
+    const user = useSelector<GlobalState, UserProfile>((state) => getUser(state, props.userId));
+    const teamnameNameDisplaySetting = useSelector<GlobalState, string | undefined>(getTeammateNameDisplaySetting) || '';
+
+    useEffect(() => {
+        if (!user) {
+            dispatch(fetchUser(props.userId));
+        }
+    }, [props.userId]);
+
+    let name = null;
+    let profileUri = null;
+    if (user) {
+        name = displayUsername(user, teamnameNameDisplaySetting);
+        profileUri = Client4.getProfilePictureUrl(props.userId, user.last_picture_update);
+    }
+
+    return (
+        <Profile>
+            <ProfilePic src={profileUri || ''}/>
+            <Wrapper>
+                <Name>{name}</Name>
+            </Wrapper>
+        </Profile>
+    );
+};
+
+export default ProfileVertical;

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/profile_vertical.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/profile_vertical.tsx
@@ -42,6 +42,7 @@ const ProfilePic = styled.img`
     display: inline-block;
 `;
 
+// STUB COMPONENT. NOT IN ACTIVE USE YET
 const ProfileVertical = (props: Props) => {
     const dispatch = useDispatch();
     const user = useSelector<GlobalState, UserProfile>((state) => getUser(state, props.userId));
@@ -54,15 +55,15 @@ const ProfileVertical = (props: Props) => {
     }, [props.userId]);
 
     let name = null;
-    let profileUri = null;
+    let profileUrl = '';
     if (user) {
         name = displayUsername(user, teamnameNameDisplaySetting);
-        profileUri = Client4.getProfilePictureUrl(props.userId, user.last_picture_update);
+        profileUrl = Client4.getProfilePictureUrl(props.userId, user.last_picture_update);
     }
 
     return (
         <Profile>
-            <ProfilePic src={profileUri || ''}/>
+            <ProfilePic src={profileUrl}/>
             <Wrapper>
                 <Name>{name}</Name>
             </Wrapper>

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useState} from 'react';
+import styled from 'styled-components';
+
+import {StyledTextarea} from 'src/components/backstage/styles';
+import {
+    SecondaryButtonRight,
+    TabPageContainer,
+    Title,
+} from 'src/components/backstage/incidents/shared';
+
+const Header = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const ReportTextarea = styled(StyledTextarea)`
+    margin: 8px 0 0 0;
+    height: 140px;
+    font-size: 12px;
+`;
+
+const Report = () => {
+    const [report, setReport] = useState('# What happened\n\n# Root cause\n\n# Recovery');
+
+    return (
+        <TabPageContainer>
+            <Header>
+                <Title>{'Report'}</Title>
+                <SecondaryButtonRight>{'Publish'}</SecondaryButtonRight>
+            </Header>
+            <ReportTextarea
+                value={report}
+                onChange={(e) => setReport(e.target.value)}
+            />
+        </TabPageContainer>
+    );
+};
+
+export default Report;

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
@@ -10,6 +10,8 @@ import {
     TabPageContainer,
     Title,
 } from 'src/components/backstage/incidents/shared';
+import {Incident} from 'src/types/incident';
+import {updateRetrospective} from 'src/client';
 
 const Header = styled.div`
     display: flex;
@@ -22,14 +24,26 @@ const ReportTextarea = styled(StyledTextarea)`
     font-size: 12px;
 `;
 
-const Report = () => {
-    const [report, setReport] = useState('# What happened\n\n# Root cause\n\n# Recovery');
+interface Props {
+    incident: Incident;
+}
+
+const Report = (props: Props) => {
+    const [report, setReport] = useState(props.incident.retrospective);
+
+    const saveDraftPressed = () => {
+        updateRetrospective(props.incident.id, report);
+    };
 
     return (
         <TabPageContainer>
             <Header>
                 <Title>{'Report'}</Title>
-                <SecondaryButtonRight>{'Publish'}</SecondaryButtonRight>
+                <SecondaryButtonRight
+                    onClick={saveDraftPressed}
+                >
+                    {'Save Draft'}
+                </SecondaryButtonRight>
             </Header>
             <ReportTextarea
                 value={report}

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import {StyledTextarea} from 'src/components/backstage/styles';
 import {
+    PrimaryButtonRight,
     SecondaryButtonRight,
     TabPageContainer,
     Title,
@@ -24,32 +25,72 @@ const ReportTextarea = styled(StyledTextarea)`
     font-size: 12px;
 `;
 
-interface Props {
+interface ReportProps {
     incident: Incident;
 }
 
-const Report = (props: Props) => {
+const Report = (props: ReportProps) => {
     const [report, setReport] = useState(props.incident.retrospective);
+    const [edited, setEdited] = useState(false);
 
     const saveDraftPressed = () => {
         updateRetrospective(props.incident.id, report);
+        setEdited(false);
     };
 
     return (
         <TabPageContainer>
             <Header>
                 <Title>{'Report'}</Title>
-                <SecondaryButtonRight
-                    onClick={saveDraftPressed}
-                >
-                    {'Save Draft'}
-                </SecondaryButtonRight>
+                <SaveButton
+                    edited={edited}
+                    onSave={saveDraftPressed}
+                />
             </Header>
             <ReportTextarea
                 value={report}
-                onChange={(e) => setReport(e.target.value)}
+                onChange={(e) => {
+                    setReport(e.target.value);
+                    setEdited(true);
+                }}
             />
         </TabPageContainer>
+    );
+};
+
+interface SaveButtonProps {
+    edited: boolean
+    onSave: () => void
+}
+
+const TextContainer = styled.span`
+    width: 65px;
+    flex-grow: 1;
+`;
+
+const SaveButton = (props: SaveButtonProps) => {
+    const [saved, setSaved] = useState(false);
+
+    const doSave = () => {
+        props.onSave();
+        setSaved(true);
+        setTimeout(() => setSaved(false), 1000);
+    };
+
+    if (props.edited || saved) {
+        return (
+            <PrimaryButtonRight
+                onClick={doSave}
+            >
+                <TextContainer>{saved ? 'Saved!' : 'Save Draft'}</TextContainer>
+            </PrimaryButtonRight>
+        );
+    }
+
+    return (
+        <SecondaryButtonRight>
+            <TextContainer>{'Save Draft'}</TextContainer>
+        </SecondaryButtonRight>
     );
 };
 

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
@@ -21,7 +21,8 @@ const Header = styled.div`
 
 const ReportTextarea = styled(StyledTextarea)`
     margin: 8px 0 0 0;
-    height: 140px;
+    min-height: 200px;
+    resize: vertical;
     font-size: 12px;
 `;
 

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/retrospective.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/retrospective.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import Report from 'src/components/backstage/incidents/incident_backstage/retrospective/report';
+import {Incident} from 'src/types/incident';
+import Learnings
+    from 'src/components/backstage/incidents/incident_backstage/retrospective/learnings';
+import Followups
+    from 'src/components/backstage/incidents/incident_backstage/retrospective/followups';
+import TimelineRetro
+    from 'src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro';
+import {Container, Left, Right} from 'src/components/backstage/incidents/shared';
+
+export const Retrospective = (props: { incident: Incident }) => {
+    return (
+        <Container>
+            <Left>
+                <Report/>
+                <Learnings incident={props.incident}/>
+                <Followups incident={props.incident}/>
+            </Left>
+            <Right>
+                <TimelineRetro incident={props.incident}/>
+            </Right>
+        </Container>
+    );
+};

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/retrospective.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/retrospective.tsx
@@ -3,23 +3,20 @@
 
 import React from 'react';
 
+//import Followups from 'src/components/backstage/incidents/incident_backstage/retrospective/followups';
+//import Learnings from 'src/components/backstage/incidents/incident_backstage/retrospective/learnings';
 import Report from 'src/components/backstage/incidents/incident_backstage/retrospective/report';
-import {Incident} from 'src/types/incident';
-import Learnings
-    from 'src/components/backstage/incidents/incident_backstage/retrospective/learnings';
-import Followups
-    from 'src/components/backstage/incidents/incident_backstage/retrospective/followups';
-import TimelineRetro
-    from 'src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro';
+import TimelineRetro from 'src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro';
 import {Container, Left, Right} from 'src/components/backstage/incidents/shared';
+import {Incident} from 'src/types/incident';
 
 export const Retrospective = (props: { incident: Incident }) => {
     return (
         <Container>
             <Left>
-                <Report/>
-                <Learnings incident={props.incident}/>
-                <Followups incident={props.incident}/>
+                <Report incident={props.incident}/>
+                {/*<Learnings incident={props.incident}/>*/}
+                {/*<Followups incident={props.incident}/>*/}
             </Left>
             <Right>
                 <TimelineRetro incident={props.incident}/>

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {useSelector} from 'react-redux';
+import styled from 'styled-components';
+import moment from 'moment';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getChannelsNameMapInCurrentTeam} from 'mattermost-redux/selectors/entities/channels';
+import {Team} from 'mattermost-redux/types/teams';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+
+import {Incident} from 'src/types/incident';
+import {TimelineEvent} from 'src/types/rhs';
+import RHSTimelineEventItem from 'src/components/rhs/rhs_timeline_event_item';
+import {ChannelNamesMap} from 'src/types/backstage';
+
+const TimelineLine = styled.ul`
+    margin: 24px 0;
+    padding: 0;
+    list-style: none;
+    position: relative;
+
+    :before {
+        content: '';
+        position: absolute;
+        top: 5px;
+        bottom: -10px;
+        left: 97px;
+        width: 1px;
+        background: #EFF1F5;
+    }
+`;
+
+const NoEventsNotice = styled.div`
+    margin: 35px 20px 0 20px;
+    font-size: 14px;
+    font-weight: 600;
+`;
+
+interface Props {
+    incident: Incident;
+    filteredEvents: TimelineEvent[];
+}
+
+const Timeline = (props: Props) => {
+    const channelNamesMap = useSelector<GlobalState, ChannelNamesMap>(getChannelsNameMapInCurrentTeam);
+    const team = useSelector<GlobalState, Team>(getCurrentTeam);
+
+    if (props.incident.timeline_events.length === 0) {
+        return (
+            <NoEventsNotice>
+                {'Timeline events are displayed here as they occur. Hover over an event to remove it.'}
+            </NoEventsNotice>
+        );
+    }
+
+    return (
+        <TimelineLine data-testid='timeline-view'>
+            {
+                props.filteredEvents.map((event) => (
+                    <RHSTimelineEventItem
+                        key={event.id}
+                        event={event}
+                        reportedAt={moment(props.incident.create_at)}
+                        channelNames={channelNamesMap}
+                        team={team}
+                    />
+                ))
+            }
+        </TimelineLine>
+    );
+};
+
+export default Timeline;

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline.tsx
@@ -58,17 +58,15 @@ const Timeline = (props: Props) => {
 
     return (
         <TimelineLine data-testid='timeline-view'>
-            {
-                props.filteredEvents.map((event) => (
-                    <RHSTimelineEventItem
-                        key={event.id}
-                        event={event}
-                        reportedAt={moment(props.incident.create_at)}
-                        channelNames={channelNamesMap}
-                        team={team}
-                    />
-                ))
-            }
+            {props.filteredEvents.map((event) => (
+                <RHSTimelineEventItem
+                    key={event.id}
+                    event={event}
+                    reportedAt={moment(props.incident.create_at)}
+                    channelNames={channelNamesMap}
+                    team={team}
+                />
+            ))}
         </TimelineLine>
     );
 };

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect, useState} from 'react';
+import {useDispatch, useSelector, useStore} from 'react-redux';
+import styled from 'styled-components';
+
+import {GlobalState} from 'mattermost-redux/types/store';
+import {UserProfile} from 'mattermost-redux/types/users';
+import {displayUsername} from 'mattermost-redux/utils/user_utils';
+import {getTeammateNameDisplaySetting} from 'mattermost-redux/selectors/entities/preferences';
+import {getUser as getUserAction} from 'mattermost-redux/actions/users';
+import {DispatchFunc} from 'mattermost-redux/types/actions';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
+
+import {Incident} from 'src/types/incident';
+import Timeline from 'src/components/backstage/incidents/incident_backstage/retrospective/timeline';
+import MultiCheckbox, {CheckboxOption} from 'src/components/multi_checkbox';
+import {TimelineEvent, TimelineEventsFilter, TimelineEventType} from 'src/types/rhs';
+import {setRHSEventsFilter} from 'src/actions';
+import {rhsEventsFilterForChannel} from 'src/selectors';
+import {
+    Content,
+    PrimaryButtonRight,
+    TabPageContainer,
+    Title,
+} from 'src/components/backstage/incidents/shared';
+
+const Header = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const FakeButton = styled.div`
+    display: inline-flex;
+    align-items: center;
+    color: var(--button-bg);
+    background: white;
+    border: 1px solid var(--button-bg);
+    border-radius: 4px;
+    padding: 0 14px;
+    height: 26px;
+    font-weight: 600;
+    font-size: 12px;
+    transition: all 0.15s ease-out;
+    margin-left: auto;
+
+    &:hover {
+        background: rgba(var(--button-bg-rgb), 0.08);
+    }
+
+    &:active  {
+        background: rgba(var(--button-bg-rgb), 0.16);
+    }
+
+    i {
+        display: flex;
+        font-size: 18px;
+
+        &:before {
+            margin: 0 7px 0 0;
+        }
+    }
+`;
+
+const PrimaryButtonNotRight = styled(PrimaryButtonRight)`
+    margin-left: 20px;
+`;
+
+type IdToUserFn = (userId: string) => UserProfile;
+
+const TimelineRetro = (props: { incident: Incident }) => {
+    const dispatch = useDispatch();
+    const displayPreference = useSelector<GlobalState, string | undefined>(getTeammateNameDisplaySetting) || 'username';
+    const [allEvents, setAllEvents] = useState<TimelineEvent[]>([]);
+    const [filteredEvents, setFilteredEvents] = useState<TimelineEvent[]>([]);
+    const eventsFilter = useSelector<GlobalState, TimelineEventsFilter>((state) => rhsEventsFilterForChannel(state, props.incident.channel_id));
+    const getStateFn = useStore().getState;
+    const getUserFn = (userId: string) => getUserAction(userId)(dispatch as DispatchFunc, getStateFn);
+    const selectUser = useSelector<GlobalState, IdToUserFn>((state) => (userId: string) => getUser(state, userId));
+
+    useEffect(() => {
+        setFilteredEvents(allEvents.filter((e) => showEvent(e.event_type, eventsFilter)));
+    }, [eventsFilter, allEvents]);
+
+    useEffect(() => {
+        Promise.all(props.incident.timeline_events.map(async (e) => {
+            let user = selectUser(e.subject_user_id) as UserProfile | undefined;
+
+            if (!user) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const ret = await getUserFn(e.subject_user_id) as { data?: UserProfile, error?: any };
+                if (!ret.data) {
+                    return null;
+                }
+                user = ret.data;
+            }
+            return {
+                ...e,
+                subject_display_name: displayUsername(user, displayPreference),
+            } as TimelineEvent;
+        })).then((eventArray) => {
+            setAllEvents(eventArray.filter((e) => e) as TimelineEvent[]);
+        });
+    }, [props.incident.timeline_events, displayPreference]);
+
+    const selectOption = (value: string, checked: boolean) => {
+        if (eventsFilter.all && value !== 'all') {
+            return;
+        }
+
+        dispatch(setRHSEventsFilter(props.incident.channel_id, {
+            ...eventsFilter,
+            [value]: checked,
+        }));
+    };
+
+    const filterOptions = [
+        {
+            display: 'All events',
+            value: 'all',
+            selected: eventsFilter.all,
+            disabled: false,
+        },
+        {
+            value: 'divider',
+        } as CheckboxOption,
+        {
+            display: 'Commander changes',
+            value: TimelineEventType.CommanderChanged,
+            selected: eventsFilter.commander_changed,
+            disabled: eventsFilter.all,
+        },
+        {
+            display: 'Status updates',
+            value: TimelineEventType.StatusUpdated,
+            selected: eventsFilter.status_updated,
+            disabled: eventsFilter.all,
+        },
+        {
+            display: 'Saved messages',
+            value: TimelineEventType.EventFromPost,
+            selected: eventsFilter.event_from_post,
+            disabled: eventsFilter.all,
+        },
+        {
+            display: 'Task state changes',
+            value: TimelineEventType.TaskStateModified,
+            selected: eventsFilter.task_state_modified,
+            disabled: eventsFilter.all,
+        },
+        {
+            display: 'Task assignments',
+            value: TimelineEventType.AssigneeChanged,
+            selected: eventsFilter.assignee_changed,
+            disabled: eventsFilter.all,
+        },
+        {
+            display: 'Slash commands',
+            value: TimelineEventType.RanSlashCommand,
+            selected: eventsFilter.ran_slash_command,
+            disabled: eventsFilter.all,
+        },
+        {
+            value: 'divider',
+        } as CheckboxOption,
+        {
+            display: 'Jira issue updates',
+            value: 'jira',
+            selected: eventsFilter.jira,
+            disabled: eventsFilter.all,
+        },
+        {
+            display: 'Zendesk ticket updates',
+            value: 'zendesk',
+            selected: eventsFilter.zendesk,
+            disabled: eventsFilter.all,
+        },
+        {
+            display: 'Github code changes',
+            value: 'github',
+            selected: eventsFilter.github,
+            disabled: eventsFilter.all,
+        },
+    ];
+
+    return (
+        <TabPageContainer>
+            <Header>
+                <Title>{'Timeline'}</Title>
+                <FakeButton>
+                    <MultiCheckbox
+                        options={filterOptions}
+                        onselect={selectOption}
+                    />
+                    {'Filter'}
+                </FakeButton>
+                <PrimaryButtonNotRight>
+                    <i className='icon-download-outline'/>
+                    {'Export'}
+                </PrimaryButtonNotRight>
+            </Header>
+            <Content>
+                <Timeline
+                    incident={props.incident}
+                    filteredEvents={filteredEvents}
+                />
+            </Content>
+        </TabPageContainer>
+    );
+};
+
+export default TimelineRetro;
+
+const showEvent = (eventType: string, filter: TimelineEventsFilter) => {
+    if (filter.all) {
+        return true;
+    }
+    const filterRecord = filter as unknown as Record<string, boolean>;
+    return filterRecord[eventType] ||
+        (eventType === TimelineEventType.IncidentCreated && filterRecord[TimelineEventType.StatusUpdated]);
+};

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
@@ -174,10 +174,12 @@ const TimelineRetro = (props: { incident: Incident }) => {
                     />
                     {'Filter'}
                 </FakeButton>
-                <PrimaryButtonNotRight>
+                {/*
+                    <PrimaryButtonNotRight>
                     <i className='icon-download-outline'/>
                     {'Export'}
-                </PrimaryButtonNotRight>
+                    </PrimaryButtonNotRight>
+                */}
             </Header>
             <Content>
                 <Timeline

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
@@ -35,7 +35,7 @@ const FakeButton = styled.div`
     display: inline-flex;
     align-items: center;
     color: var(--button-bg);
-    background: white;
+    background: var(--button-color-rgb);
     border: 1px solid var(--button-bg);
     border-radius: 4px;
     padding: 0 14px;

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/timeline_retro.tsx
@@ -161,27 +161,6 @@ const TimelineRetro = (props: { incident: Incident }) => {
             selected: eventsFilter.ran_slash_command,
             disabled: eventsFilter.all,
         },
-        {
-            value: 'divider',
-        } as CheckboxOption,
-        {
-            display: 'Jira issue updates',
-            value: 'jira',
-            selected: eventsFilter.jira,
-            disabled: eventsFilter.all,
-        },
-        {
-            display: 'Zendesk ticket updates',
-            value: 'zendesk',
-            selected: eventsFilter.zendesk,
-            disabled: eventsFilter.all,
-        },
-        {
-            display: 'Github code changes',
-            value: 'github',
-            selected: eventsFilter.github,
-            disabled: eventsFilter.all,
-        },
     ];
 
     return (

--- a/webapp/src/components/rhs/rhs_welcome_view.tsx
+++ b/webapp/src/components/rhs/rhs_welcome_view.tsx
@@ -35,6 +35,11 @@ const NoIncidentsItem = styled.div`
     margin-bottom: 24px;
 `;
 
+const SideBySide = styled.span`
+    display: flex;
+    align-items: center;
+`;
+
 const RHSWelcomeView = () => {
     const dispatch = useDispatch();
     const currentTeam = useSelector<GlobalState, Team>(getCurrentTeam);
@@ -64,10 +69,10 @@ const RHSWelcomeView = () => {
                             <PrimaryButton
                                 onClick={() => dispatch(startIncident())}
                             >
-                                <span>
+                                <SideBySide>
                                     <i className='icon-plus icon--no-spacing mr-2'/>
                                     {'Start Incident'}
-                                </span>
+                                </SideBySide>
                             </PrimaryButton>
                         </div>
                         <p className='mt-3 mb-4 light'>

--- a/webapp/src/types/incident.ts
+++ b/webapp/src/types/incident.ts
@@ -26,6 +26,7 @@ export interface Incident {
     reminder_post_id: string;
     broadcast_channel_id: string;
     timeline_events: TimelineEvent[];
+    retrospective: string;
 }
 
 export interface StatusPost {


### PR DESCRIPTION
#### Summary
Infrastructure for the backstage retrospective tab. This is all behind the experimental features flag for now. All this is is the tab and and editable field in the backstage. Pressing the save button will save a "draft" that you can't do anything with for now. 

Thanks to @cpoile for the client framework and timeline which is the basis for this PR. 

FYI and feedback appreciated @itao @abhijit-singh 

#### Where we are
- **Placeholder Elements**
- **Basic saving of retrospective** <-- We are here
- Ability to publish retrospective
- Reminder to fill out retrospective
- Templating retrospective report
- Configurable persistant reminders
- Polish

#### Retrospective tab:
![image](https://user-images.githubusercontent.com/3191642/117082010-f5754380-acf5-11eb-8e4a-97b40c467432.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35041
https://mattermost.atlassian.net/browse/MM-35042
