### PR TITLE
MM-17468: Accept a number of days instead of two date arguments in `/incident test bulk-data`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,19 +5,19 @@ With regard to the Mattermost Software:
 
 This software and associated documentation files (the "Software") may only be
 used in production, if you (and any entity that you represent) have agreed to,
-and are in compliance with, the Mattermost Terms of Service, available at
-https://mattermost.com/enterprise-edition-terms/ (the “EE Terms”), or other
-agreement governing the use of the Software, as agreed by you and Mattermost,
-and otherwise have a valid Mattermost Enterprise E20 subscription for the
-correct number of user seats. Subject to the foregoing sentence, you are free
+and are in compliance with all of the following: (a) the Mattermost Terms of Service, available at
+https://mattermost.com/enterprise-edition-terms/ (the “EE Terms”), (b) any other
+agreement(s) governing the use of the Software, as agreed upon by you and Mattermost,
+and (c) you otherwise have a valid license or Subscription for the
+correct number of Registered Authorized Users of the Software. Subject to the foregoing, you are free
 to modify this Software and publish patches to the Software. You agree that
 Mattermost and/or its licensors (as applicable) retain all right, title and
 interest in and to all such modifications and/or patches, and all such
 modifications and/or patches may only be used, copied, modified, displayed,
-distributed, or otherwise exploited with a valid Mattermost Enterprise E20
-Edition subscription for the  correct number of user seats.  Notwithstanding
+distributed, or otherwise exploited with a valid license or Subscription for the correct number of 
+Registered Authorized Users of the Software.  Notwithstanding
 the foregoing, you may copy and modify the Software for development and testing
-purposes, without requiring a subscription.  You agree that Mattermost and/or
+purposes, without requiring a valid license or Subscription.  You agree that Mattermost and/or
 its licensors (as applicable) retain all right, title and interest in and to
 all such modifications.  You are not granted any other rights beyond what is
 expressly stated herein.  Subject to the foregoing, it is forbidden to copy,

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ To quickly test Mattermost Incident Collaboration, use the following test comman
 
   * An example command looks like: `/incident test create-incident 6utgh6qg7p8ndeef9edc583cpc 2020-11-23 PR-Testing`
 
-- `/incident test bulk-data [ongoing] [ended] [start date] [end date] [seed]` - Provide a number of ongoing and ended incidents, a start and end date, and an optional random seed. The command creates the given number of ongoing and ended incidents, with creation dates randomly between the start and end dates. The seed may be used to reproduce the same outcome on multiple invocations. Incident names are generated randomly.
+- `/incident test bulk-data [ongoing] [ended] [days] [seed]` - Provide a number of ongoing and ended incidents, a number of days, and an optional random seed. The command creates the given number of ongoing and ended incidents, with creation dates randomly between n days ago and the day when the command was issued. The seed may be used to reproduce the same outcome on multiple invocations. Incident names are generated randomly.
 
-  * An example command looks like: `/incident test bulk-data 10 3 2020-01-31 2020-11-22 2`
+  * An example command looks like: `/incident test bulk-data 10 3 342 2`
 
 ## Contributing
 

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -1147,7 +1147,7 @@ func (r *Runner) actionTestData(params []string) {
 
 	begin, err := time.ParseInLocation("2006-01-02", time.Now().AddDate(0, 0, -days).Format("2006-01-02"), time.Now().Location())
 	if err != nil {
-		r.warnUserAndLogErrorf("unable to parse in location on time.Now(): %v", err)
+		r.warnUserAndLogErrorf("unable to parse in location on time.Now().AddDate: %v", err)
 		return
 	}
 

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -133,8 +133,7 @@ func getAutocompleteData(addTestCommands bool) *model.AutocompleteData {
 		testData := model.NewAutocompleteData("bulk-data", "[ongoing] [ended] [days] [seed]", "Generate random test data in bulk")
 		testData.AddTextArgument("An integer indicating how many ongoing incidents will be generated.", "Number of ongoing incidents", "")
 		testData.AddTextArgument("An integer indicating how many ended incidents will be generated.", "Number of ended incidents", "")
-		testData.AddTextArgument("Date in format 2020-01-31", "First possible creation date", "")
-		testData.AddTextArgument("Date in format 2020-01-31", "Last possible creation date", "")
+		testData.AddTextArgument("An integer n. The incidents generated will have a start date between n days ago and today.", "Range of days for the incident start date", "")
 		testData.AddTextArgument("An integer in case you need random, but reproducible, results", "Random seed (optional)", "")
 		test.AddCommand(testData)
 
@@ -1145,17 +1144,8 @@ func (r *Runner) actionTestData(params []string) {
 		return
 	}
 
-	begin, err := time.ParseInLocation("2006-01-02", time.Now().AddDate(0, 0, -days).Format("2006-01-02"), time.Now().Location())
-	if err != nil {
-		r.warnUserAndLogErrorf("unable to parse in location on time.Now().AddDate: %v", err)
-		return
-	}
-
-	end, err := time.ParseInLocation("2006-01-02", time.Now().Format("2006-01-02"), time.Now().Location())
-	if err != nil {
-		r.warnUserAndLogErrorf("unable to parse in location on time.Now(): %v", err)
-		return
-	}
+	begin := time.Now().AddDate(0, 0, -days)
+	end := time.Now()
 
 	seed := time.Now().Unix()
 	if len(params) > 3 {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR is for simplifying two date arguments in `/incident test bulk-data` into one number argument. Instead of `/incident test bulk-data 10 3 2020-01-31 2020-11-22 2`, now it's `/incident test bulk-data 10 3 342 2`. And the number of days is expected to be larger than 0.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/17468

