### PR TITLE
MM-35557 - Fix 400 bad request error when switching to automation tab

### DIFF
--- a/webapp/src/components/backstage/automation/invite_users_selector.tsx
+++ b/webapp/src/components/backstage/automation/invite_users_selector.tsx
@@ -1,8 +1,11 @@
 import React, {FC, useState, useEffect} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
-
-import ReactSelect, {GroupType, ControlProps, OptionsType, MenuListComponentProps} from 'react-select';
-
+import {useSelector} from 'react-redux';
+import ReactSelect, {
+    GroupType,
+    ControlProps,
+    OptionsType,
+    MenuListComponentProps,
+} from 'react-select';
 import {Scrollbars} from 'react-custom-scrollbars';
 
 import styled from 'styled-components';
@@ -10,9 +13,9 @@ import {ActionFunc} from 'mattermost-redux/types/actions';
 import {UserProfile} from 'mattermost-redux/types/users';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {getUser} from 'mattermost-redux/selectors/entities/users';
-import {getProfilesByIds} from 'mattermost-redux/actions/users';
 
 import Profile from 'src/components/profile/profile';
+import {useEnsureProfiles} from 'src/hooks';
 
 interface Props {
     userIds: string[];
@@ -24,14 +27,10 @@ interface Props {
 }
 
 const InviteUsersSelector: FC<Props> = (props: Props) => {
-    const dispatch = useDispatch();
     const [searchTerm, setSearchTerm] = useState('');
     const invitedUsers = useSelector<GlobalState, UserProfile[]>((state: GlobalState) => props.userIds.map((id) => getUser(state, id)));
     const [searchedUsers, setSearchedUsers] = useState<UserProfile[]>([]);
-
-    useEffect(() => {
-        dispatch(getProfilesByIds(props.userIds));
-    }, [props.userIds]);
+    useEnsureProfiles(props.userIds);
 
     // Update the options whenever the passed user IDs or the search term are updated
     useEffect(() => {
@@ -50,7 +49,7 @@ const InviteUsersSelector: FC<Props> = (props: Props) => {
         };
 
         updateOptions(searchTerm);
-    }, [props.userIds, searchTerm]);
+    }, [searchTerm]);
 
     let invitedProfiles: UserProfile[] = [];
     let nonInvitedProfiles: UserProfile[] = [];
@@ -157,7 +156,7 @@ const Remove = styled.span`
     color: rgba(var(--center-channel-color-rgb), 0.56);
 
     :hover {
-    cursor: pointer;
+        cursor: pointer;
     }
 `;
 


### PR DESCRIPTION
#### Summary
- The problem was we were making a user profile request with an empty list of ids, so don't do that
- But also: refactor that into a `useEnsure` hook which will only request profiles that we don't already have in the store
- Also, clean up hooks so that hooks are named with `use` and helper functions are not (they aren't hooks)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35557