### PR TITLE
MM-35551 Fix menu visibility issues on enable/disable

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {Store} from 'redux';
+import {Store, Unsubscribe} from 'redux';
 import {debounce} from 'debounce';
 
 import {GlobalState} from 'mattermost-redux/types/store';
@@ -49,6 +49,9 @@ import {makeUpdateMainMenu} from './make_update_main_menu';
 import {fetchGlobalSettings} from './client';
 
 export default class Plugin {
+    removeMainMenuSub?: Unsubscribe;
+    removeRHSListener?: Unsubscribe;
+
     public initialize(registry: PluginRegistry, store: Store<GlobalState>): void {
         registry.registerReducer(reducer);
 
@@ -57,7 +60,7 @@ export default class Plugin {
 
         // Would rather use a saga and listen for ActionTypes.UPDATE_MOBILE_VIEW.
         window.addEventListener('resize', debounce(updateMainMenuAction, 300));
-        store.subscribe(updateMainMenuAction);
+        this.removeMainMenuSub = store.subscribe(updateMainMenuAction);
 
         registry.registerAdminConsoleCustomSetting('EnabledTeams', SystemConsoleEnabledTeams, {showTitle: true});
 
@@ -92,7 +95,10 @@ export default class Plugin {
             r.registerWebSocketEventHandler(WebsocketEvents.CHANNEL_UPDATED, handleWebsocketChannelUpdated(store.getState, store.dispatch));
 
             // Listen for channel changes and open the RHS when appropriate.
-            store.subscribe(makeRHSOpener(store));
+            if (this.removeRHSListener) {
+                this.removeRHSListener();
+            }
+            this.removeRHSListener = store.subscribe(makeRHSOpener(store));
 
             r.registerSlashCommandWillBePostedHook(makeSlashCommandHook(store));
 
@@ -119,6 +125,15 @@ export default class Plugin {
         };
         registry.registerWebSocketEventHandler(WebsocketEvents.LICENSE_CHANGED, checkRegistrations);
         checkRegistrations();
+    }
+
+    public uninitialize() {
+        if (this.removeMainMenuSub) {
+            this.removeMainMenuSub();
+        }
+        if (this.removeRHSListener) {
+            this.removeRHSListener();
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
Adds unregistration step for the two listeners we added to the redux store. 

When the plugin was enabled/disabled on a running server with an active webapp, the previous redux listeners would not be removed automatically (since it doesn't run though the plugin system). So phantom RHS opening and main menu items could appear under certain conditions. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35551

