### PR TITLE
MM-35600 - Fix JS error on change commander

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -16,6 +16,7 @@ import (
 
 // Handler Root API handler.
 type Handler struct {
+	*ErrorHandler
 	pluginAPI *pluginapi.Client
 	APIRouter *mux.Router
 	root      *mux.Router
@@ -26,9 +27,10 @@ type Handler struct {
 // NewHandler constructs a new handler.
 func NewHandler(pluginAPI *pluginapi.Client, config config.Service, log bot.Logger) *Handler {
 	handler := &Handler{
-		pluginAPI: pluginAPI,
-		config:    config,
-		log:       log,
+		ErrorHandler: &ErrorHandler{log: log},
+		pluginAPI:    pluginAPI,
+		config:       config,
+		log:          log,
 	}
 
 	root := mux.NewRouter()
@@ -90,17 +92,6 @@ func (h *Handler) setSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-}
-
-// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
-func (h *Handler) HandleError(w http.ResponseWriter, internalErr error) {
-	h.HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
-}
-
-// HandleErrorWithCode logs the internal error and sends the public facing error
-// message as JSON in a response with the provided code.
-func (h *Handler) HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
-	HandleErrorWithCode(h.log, w, code, publicErrorMsg, internalErr)
 }
 
 // HandleErrorWithCode logs the internal error and sends the public facing error

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -21,7 +21,6 @@ type Handler struct {
 	APIRouter *mux.Router
 	root      *mux.Router
 	config    config.Service
-	log       bot.Logger
 }
 
 // NewHandler constructs a new handler.
@@ -30,7 +29,6 @@ func NewHandler(pluginAPI *pluginapi.Client, config config.Service, log bot.Logg
 		ErrorHandler: &ErrorHandler{log: log},
 		pluginAPI:    pluginAPI,
 		config:       config,
-		log:          log,
 	}
 
 	root := mux.NewRouter()

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -124,7 +124,7 @@ func HandleErrorWithCode(logger bot.Logger, w http.ResponseWriter, code int, pub
 	_, _ = w.Write(responseMsg)
 }
 
-// ReturnJSON writes the given pointer to object as json with a success response
+// ReturnJSON writes the given pointerToObject as json with the provided httpStatus
 func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}, httpStatus int) {
 	jsonBytes, err := json.Marshal(pointerToObject)
 	if err != nil {

--- a/server/api/api_test.go
+++ b/server/api/api_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	mock_poster "github.com/mattermost/mattermost-plugin-incident-collaboration/server/bot/mocks"
+
 	"github.com/golang/mock/gomock"
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 	icClient "github.com/mattermost/mattermost-plugin-incident-collaboration/client"
@@ -38,7 +40,8 @@ func TestAPI(t *testing.T) {
 			configService := mock_config.NewMockService(mockCtrl)
 			pluginAPI := &plugintest.API{}
 			client := pluginapi.NewClient(pluginAPI)
-			handler := NewHandler(client, configService)
+			logger := mock_poster.NewMockLogger(mockCtrl)
+			handler := NewHandler(client, configService, logger)
 
 			writer := httptest.NewRecorder()
 			tc.test(t, handler, writer)

--- a/server/api/error_handler.go
+++ b/server/api/error_handler.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/bot"
+)
+
+type ErrorHandler struct {
+	log bot.Logger
+}
+
+// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
+func (h *ErrorHandler) HandleError(w http.ResponseWriter, internalErr error) {
+	h.HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
+}
+
+// HandleErrorWithCode logs the internal error and sends the public facing error
+// message as JSON in a response with the provided code.
+func (h *ErrorHandler) HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
+	HandleErrorWithCode(h.log, w, code, publicErrorMsg, internalErr)
+}

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -691,7 +691,7 @@ func (h *IncidentHandler) changeCommander(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	ReturnJSON(w, map[string]interface{}{}, http.StatusOK)
 }
 
 // updateStatusD handles the POST /incidents/{id}/status endpoint, user has edit permissions

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -25,6 +25,7 @@ import (
 
 // IncidentHandler is the API handler.
 type IncidentHandler struct {
+	*ErrorHandler
 	config          config.Service
 	incidentService incident.Service
 	playbookService playbook.Service
@@ -38,6 +39,7 @@ type IncidentHandler struct {
 func NewIncidentHandler(router *mux.Router, incidentService incident.Service, playbookService playbook.Service,
 	api *pluginapi.Client, poster bot.Poster, log bot.Logger, telemetry incident.Telemetry, config config.Service) *IncidentHandler {
 	handler := &IncidentHandler{
+		ErrorHandler:    &ErrorHandler{log: log},
 		incidentService: incidentService,
 		playbookService: playbookService,
 		pluginAPI:       api,
@@ -102,17 +104,6 @@ func NewIncidentHandler(router *mux.Router, incidentService incident.Service, pl
 	telemetryRouterAuthorized.HandleFunc("/incident/{id:[A-Za-z0-9]+}", handler.telemetryForIncident).Methods(http.MethodPost)
 
 	return handler
-}
-
-// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
-func (h *IncidentHandler) HandleError(w http.ResponseWriter, internalErr error) {
-	h.HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
-}
-
-// HandleErrorWithCode logs the internal error and sends the public facing error
-// message as JSON in a response with the provided code.
-func (h *IncidentHandler) HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
-	HandleErrorWithCode(h.log, w, code, publicErrorMsg, internalErr)
 }
 
 func (h *IncidentHandler) checkEditPermissions(next http.Handler) http.Handler {

--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -104,6 +104,17 @@ func NewIncidentHandler(router *mux.Router, incidentService incident.Service, pl
 	return handler
 }
 
+// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
+func (h *IncidentHandler) HandleError(w http.ResponseWriter, internalErr error) {
+	h.HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
+}
+
+// HandleErrorWithCode logs the internal error and sends the public facing error
+// message as JSON in a response with the provided code.
+func (h *IncidentHandler) HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
+	HandleErrorWithCode(h.log, w, code, publicErrorMsg, internalErr)
+}
+
 func (h *IncidentHandler) checkEditPermissions(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -111,16 +122,16 @@ func (h *IncidentHandler) checkEditPermissions(next http.Handler) http.Handler {
 
 		incdnt, err := h.incidentService.GetIncident(vars["id"])
 		if err != nil {
-			HandleError(w, err)
+			h.HandleError(w, err)
 			return
 		}
 
 		if err := permissions.EditIncident(userID, incdnt.ChannelID, h.pluginAPI); err != nil {
 			if errors.Is(err, permissions.ErrNoPermissions) {
-				HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
+				h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
 				return
 			}
-			HandleError(w, err)
+			h.HandleError(w, err)
 			return
 		}
 
@@ -135,16 +146,16 @@ func (h *IncidentHandler) checkViewPermissions(next http.Handler) http.Handler {
 
 		incdnt, err := h.incidentService.GetIncident(vars["id"])
 		if err != nil {
-			HandleError(w, err)
+			h.HandleError(w, err)
 			return
 		}
 
 		if err := permissions.ViewIncidentFromChannelID(userID, incdnt.ChannelID, h.pluginAPI); err != nil {
 			if errors.Is(err, permissions.ErrNoPermissions) {
-				HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
+				h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
 				return
 			}
-			HandleError(w, err)
+			h.HandleError(w, err)
 			return
 		}
 
@@ -158,12 +169,12 @@ func (h *IncidentHandler) createIncidentFromPost(w http.ResponseWriter, r *http.
 
 	var incidentCreateOptions client.IncidentCreateOptions
 	if err := json.NewDecoder(r.Body).Decode(&incidentCreateOptions); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode incident create options", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode incident create options", err)
 		return
 	}
 
 	if !permissions.IsOnEnabledTeam(incidentCreateOptions.TeamID, h.config) {
-		HandleErrorWithCode(w, http.StatusBadRequest, "not enabled on this team", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "not enabled on this team", nil)
 		return
 	}
 
@@ -179,17 +190,17 @@ func (h *IncidentHandler) createIncidentFromPost(w http.ResponseWriter, r *http.
 	newIncident, err := h.createIncident(payloadIncident, userID)
 
 	if errors.Is(err, incident.ErrPermission) {
-		HandleErrorWithCode(w, http.StatusForbidden, "unable to create incident", err)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "unable to create incident", err)
 		return
 	}
 
 	if errors.Is(err, incident.ErrMalformedIncident) {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to create incident", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to create incident", err)
 		return
 	}
 
 	if err != nil {
-		HandleError(w, errors.Wrapf(err, "unable to create incident"))
+		h.HandleError(w, errors.Wrapf(err, "unable to create incident"))
 		return
 	}
 
@@ -209,13 +220,13 @@ func (h *IncidentHandler) updateIncident(w http.ResponseWriter, r *http.Request)
 
 	oldIncident, err := h.incidentService.GetIncident(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	var updates incident.UpdateOptions
 	if err = json.NewDecoder(r.Body).Decode(&updates); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode payload", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode payload", err)
 		return
 	}
 
@@ -231,24 +242,24 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 
 	request := model.SubmitDialogRequestFromJson(r.Body)
 	if request == nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
 		return
 	}
 
 	if userID != request.UserId {
-		HandleErrorWithCode(w, http.StatusBadRequest, "interactive dialog's userID must be the same as the requester's userID", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "interactive dialog's userID must be the same as the requester's userID", nil)
 		return
 	}
 
 	if !permissions.IsOnEnabledTeam(request.TeamId, h.config) {
-		HandleErrorWithCode(w, http.StatusBadRequest, "not enabled on this team", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "not enabled on this team", nil)
 		return
 	}
 
 	var state incident.DialogState
 	err := json.Unmarshal([]byte(request.State), &state)
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal dialog state", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal dialog state", err)
 		return
 	}
 
@@ -271,7 +282,7 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 	newIncident, err := h.createIncident(payloadIncident, request.UserId)
 	if err != nil {
 		if errors.Is(err, incident.ErrMalformedIncident) {
-			HandleErrorWithCode(w, http.StatusBadRequest, "unable to create incident", err)
+			h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to create incident", err)
 			return
 		}
 
@@ -293,7 +304,7 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 			return
 		}
 
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -303,7 +314,7 @@ func (h *IncidentHandler) createIncidentFromDialog(w http.ResponseWriter, r *htt
 	}, request.UserId)
 
 	if err := h.postIncidentCreatedMessage(newIncident, request.ChannelId); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -318,12 +329,12 @@ func (h *IncidentHandler) addToTimelineDialog(w http.ResponseWriter, r *http.Req
 
 	request := model.SubmitDialogRequestFromJson(r.Body)
 	if request == nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
 		return
 	}
 
 	if userID != request.UserId {
-		HandleErrorWithCode(w, http.StatusBadRequest, "interactive dialog's userID must be the same as the requester's userID", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "interactive dialog's userID must be the same as the requester's userID", nil)
 		return
 	}
 
@@ -337,7 +348,7 @@ func (h *IncidentHandler) addToTimelineDialog(w http.ResponseWriter, r *http.Req
 
 	incdnt, incErr := h.incidentService.GetIncident(incidentID)
 	if incErr != nil {
-		HandleError(w, incErr)
+		h.HandleError(w, incErr)
 		return
 	}
 
@@ -348,12 +359,12 @@ func (h *IncidentHandler) addToTimelineDialog(w http.ResponseWriter, r *http.Req
 	var state incident.DialogStateAddToTimeline
 	err := json.Unmarshal([]byte(request.State), &state)
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal dialog state", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal dialog state", err)
 		return
 	}
 
 	if err = h.incidentService.AddPostToTimeline(incidentID, userID, state.PostID, summary); err != nil {
-		HandleError(w, errors.Wrap(err, "failed to add post to timeline"))
+		h.HandleError(w, errors.Wrap(err, "failed to add post to timeline"))
 		return
 	}
 
@@ -466,14 +477,14 @@ func (h *IncidentHandler) getRequesterInfo(userID string) (permissions.Requester
 func (h *IncidentHandler) getIncidents(w http.ResponseWriter, r *http.Request) {
 	filterOptions, err := parseIncidentsFilterOptions(r.URL)
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "Bad parameter", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Bad parameter", err)
 		return
 	}
 
 	userID := r.Header.Get("Mattermost-User-ID")
 	// More detailed permissions checked on DB level.
 	if !permissions.CanViewTeam(userID, filterOptions.TeamID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "permissions error", errors.Errorf(
+		h.HandleErrorWithCode(w, http.StatusForbidden, "permissions error", errors.Errorf(
 			"userID %s does not have view permission for teamID %s", userID, filterOptions.TeamID))
 		return
 	}
@@ -485,13 +496,13 @@ func (h *IncidentHandler) getIncidents(w http.ResponseWriter, r *http.Request) {
 
 	requesterInfo, err := h.getRequesterInfo(userID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	results, err := h.incidentService.GetIncidents(requesterInfo, *filterOptions)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -506,12 +517,12 @@ func (h *IncidentHandler) getIncident(w http.ResponseWriter, r *http.Request) {
 
 	incidentToGet, err := h.incidentService.GetIncident(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if err := permissions.ViewIncidentFromChannelID(userID, incidentToGet.ChannelID, h.pluginAPI); err != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "User doesn't have permissions to incident.", nil)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "User doesn't have permissions to incident.", nil)
 		return
 	}
 
@@ -526,19 +537,19 @@ func (h *IncidentHandler) getIncidentMetadata(w http.ResponseWriter, r *http.Req
 
 	incidentToGet, incErr := h.incidentService.GetIncident(incidentID)
 	if incErr != nil {
-		HandleError(w, incErr)
+		h.HandleError(w, incErr)
 		return
 	}
 
 	if err := permissions.ViewIncidentFromChannelID(userID, incidentToGet.ChannelID, h.pluginAPI); err != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized",
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized",
 			errors.Errorf("userid: %s does not have permissions to view the incident details", userID))
 		return
 	}
 
 	incidentMetadata, err := h.incidentService.GetIncidentMetadata(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -553,7 +564,7 @@ func (h *IncidentHandler) getIncidentByChannel(w http.ResponseWriter, r *http.Re
 
 	if err := permissions.ViewIncidentFromChannelID(userID, channelID, h.pluginAPI); err != nil {
 		h.log.Warnf("User %s does not have permissions to get incident for channel %s", userID, channelID)
-		HandleErrorWithCode(w, http.StatusNotFound, "Not found",
+		h.HandleErrorWithCode(w, http.StatusNotFound, "Not found",
 			errors.Errorf("incident for channel id %s not found", channelID))
 		return
 	}
@@ -561,18 +572,18 @@ func (h *IncidentHandler) getIncidentByChannel(w http.ResponseWriter, r *http.Re
 	incidentID, err := h.incidentService.GetIncidentIDForChannel(channelID)
 	if err != nil {
 		if errors.Is(err, incident.ErrNotFound) {
-			HandleErrorWithCode(w, http.StatusNotFound, "Not found",
+			h.HandleErrorWithCode(w, http.StatusNotFound, "Not found",
 				errors.Errorf("incident for channel id %s not found", channelID))
 
 			return
 		}
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	incidentToGet, err := h.incidentService.GetIncident(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -583,12 +594,12 @@ func (h *IncidentHandler) getIncidentByChannel(w http.ResponseWriter, r *http.Re
 func (h *IncidentHandler) getCommanders(w http.ResponseWriter, r *http.Request) {
 	teamID := r.URL.Query().Get("team_id")
 	if teamID == "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "Bad parameter: team_id", errors.New("team_id required"))
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Bad parameter: team_id", errors.New("team_id required"))
 	}
 
 	userID := r.Header.Get("Mattermost-User-ID")
 	if !permissions.CanViewTeam(userID, teamID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "permissions error", errors.Errorf(
+		h.HandleErrorWithCode(w, http.StatusForbidden, "permissions error", errors.Errorf(
 			"userID %s does not have view permission for teamID %s",
 			userID,
 			teamID,
@@ -602,13 +613,13 @@ func (h *IncidentHandler) getCommanders(w http.ResponseWriter, r *http.Request) 
 
 	requesterInfo, err := h.getRequesterInfo(userID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	commanders, err := h.incidentService.GetCommanders(requesterInfo, options)
 	if err != nil {
-		HandleError(w, errors.Wrapf(err, "failed to get commanders"))
+		h.HandleError(w, errors.Wrapf(err, "failed to get commanders"))
 		return
 	}
 
@@ -622,13 +633,13 @@ func (h *IncidentHandler) getCommanders(w http.ResponseWriter, r *http.Request) 
 func (h *IncidentHandler) getChannels(w http.ResponseWriter, r *http.Request) {
 	filterOptions, err := parseIncidentsFilterOptions(r.URL)
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "Bad parameter", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Bad parameter", err)
 		return
 	}
 
 	userID := r.Header.Get("Mattermost-User-ID")
 	if !permissions.CanViewTeam(userID, filterOptions.TeamID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "permissions error", errors.Errorf(
+		h.HandleErrorWithCode(w, http.StatusForbidden, "permissions error", errors.Errorf(
 			"userID %s does not have view permission for teamID %s",
 			userID,
 			filterOptions.TeamID,
@@ -638,13 +649,13 @@ func (h *IncidentHandler) getChannels(w http.ResponseWriter, r *http.Request) {
 
 	requesterInfo, err := h.getRequesterInfo(userID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	incidents, err := h.incidentService.GetIncidents(requesterInfo, *filterOptions)
 	if err != nil {
-		HandleError(w, errors.Wrapf(err, "failed to get commanders"))
+		h.HandleError(w, errors.Wrapf(err, "failed to get commanders"))
 		return
 	}
 
@@ -665,29 +676,29 @@ func (h *IncidentHandler) changeCommander(w http.ResponseWriter, r *http.Request
 		CommanderID string `json:"commander_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "could not decode request body", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "could not decode request body", err)
 		return
 	}
 
 	incdnt, err := h.incidentService.GetIncident(vars["id"])
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	// Check if the target user (params.CommanderID) has permissions
 	if err := permissions.EditIncident(params.CommanderID, incdnt.ChannelID, h.pluginAPI); err != nil {
 		if errors.Is(err, permissions.ErrNoPermissions) {
-			HandleErrorWithCode(w, http.StatusForbidden, "Not authorized",
+			h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized",
 				errors.Errorf("userid: %s does not have permissions to incident channel; cannot be made commander", params.CommanderID))
 			return
 		}
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if err := h.incidentService.ChangeCommander(vars["id"], userID, params.CommanderID); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -701,30 +712,30 @@ func (h *IncidentHandler) status(w http.ResponseWriter, r *http.Request) {
 
 	incidentToModify, err := h.incidentService.GetIncident(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if !permissions.CanPostToChannel(userID, incidentToModify.ChannelID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", fmt.Errorf("user %s cannot post to incident channel %s", userID, incidentToModify.ChannelID))
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", fmt.Errorf("user %s cannot post to incident channel %s", userID, incidentToModify.ChannelID))
 		return
 	}
 
 	var options incident.StatusUpdateOptions
 	if err = json.NewDecoder(r.Body).Decode(&options); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode body into StatusUpdateOptions", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode body into StatusUpdateOptions", err)
 		return
 	}
 
 	options.Description = strings.TrimSpace(options.Description)
 	if options.Description == "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "description must not be empty", errors.New("description field empty"))
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "description must not be empty", errors.New("description field empty"))
 		return
 	}
 
 	options.Message = strings.TrimSpace(options.Message)
 	if options.Message == "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "message must not be empty", errors.New("message field empty"))
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "message must not be empty", errors.New("message field empty"))
 		return
 	}
 
@@ -732,7 +743,7 @@ func (h *IncidentHandler) status(w http.ResponseWriter, r *http.Request) {
 
 	options.Status = strings.TrimSpace(options.Status)
 	if options.Status == "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "status must not be empty", errors.New("status field empty"))
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "status must not be empty", errors.New("status field empty"))
 		return
 	}
 	switch options.Status {
@@ -742,13 +753,13 @@ func (h *IncidentHandler) status(w http.ResponseWriter, r *http.Request) {
 	case incident.StatusResolved:
 		break
 	default:
-		HandleErrorWithCode(w, http.StatusBadRequest, "invalid status", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "invalid status", nil)
 		return
 	}
 
 	err = h.incidentService.UpdateStatus(incidentID, userID, options)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -764,18 +775,18 @@ func (h *IncidentHandler) updateStatusDialog(w http.ResponseWriter, r *http.Requ
 
 	incidentToModify, err := h.incidentService.GetIncident(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if !permissions.CanPostToChannel(userID, incidentToModify.ChannelID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", fmt.Errorf("user %s cannot post to incident channel %s", userID, incidentToModify.ChannelID))
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", fmt.Errorf("user %s cannot post to incident channel %s", userID, incidentToModify.ChannelID))
 		return
 	}
 
 	request := model.SubmitDialogRequestFromJson(r.Body)
 	if request == nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
 		return
 	}
 
@@ -815,13 +826,13 @@ func (h *IncidentHandler) updateStatusDialog(w http.ResponseWriter, r *http.Requ
 	case incident.StatusResolved:
 		break
 	default:
-		HandleErrorWithCode(w, http.StatusBadRequest, "invalid status", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "invalid status", nil)
 		return
 	}
 
 	err = h.incidentService.UpdateStatus(incidentID, userID, options)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -833,13 +844,13 @@ func (h *IncidentHandler) updateStatusDialog(w http.ResponseWriter, r *http.Requ
 func (h *IncidentHandler) reminderButtonUpdate(w http.ResponseWriter, r *http.Request) {
 	requestData := model.PostActionIntegrationRequestFromJson(r.Body)
 	if requestData == nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "missing request data", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "missing request data", nil)
 		return
 	}
 
 	incidentID, err := h.incidentService.GetIncidentIDForChannel(requestData.ChannelId)
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusInternalServerError, "error getting incident",
+		h.HandleErrorWithCode(w, http.StatusInternalServerError, "error getting incident",
 			errors.Wrapf(err, "reminderButtonUpdate failed to find incidentID for channelID: %s", requestData.ChannelId))
 		return
 	}
@@ -849,12 +860,12 @@ func (h *IncidentHandler) reminderButtonUpdate(w http.ResponseWriter, r *http.Re
 			ReturnJSON(w, nil, http.StatusForbidden)
 			return
 		}
-		HandleErrorWithCode(w, http.StatusInternalServerError, "error getting permissions", err)
+		h.HandleErrorWithCode(w, http.StatusInternalServerError, "error getting permissions", err)
 		return
 	}
 
 	if err = h.incidentService.OpenUpdateStatusDialog(incidentID, requestData.TriggerId); err != nil {
-		HandleError(w, errors.New("reminderButtonUpdate failed to open update status dialog"))
+		h.HandleError(w, errors.New("reminderButtonUpdate failed to open update status dialog"))
 		return
 	}
 
@@ -866,14 +877,14 @@ func (h *IncidentHandler) reminderButtonUpdate(w http.ResponseWriter, r *http.Re
 func (h *IncidentHandler) reminderButtonDismiss(w http.ResponseWriter, r *http.Request) {
 	requestData := model.PostActionIntegrationRequestFromJson(r.Body)
 	if requestData == nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "missing request data", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "missing request data", nil)
 		return
 	}
 
 	incidentID, err := h.incidentService.GetIncidentIDForChannel(requestData.ChannelId)
 	if err != nil {
 		h.log.Errorf("reminderButtonDismiss: no incident for requestData's channelID: %s", requestData.ChannelId)
-		HandleErrorWithCode(w, http.StatusBadRequest, "no incident for requestData's channelID", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "no incident for requestData's channelID", err)
 		return
 	}
 
@@ -882,13 +893,13 @@ func (h *IncidentHandler) reminderButtonDismiss(w http.ResponseWriter, r *http.R
 			ReturnJSON(w, nil, http.StatusForbidden)
 			return
 		}
-		HandleErrorWithCode(w, http.StatusInternalServerError, "error getting permissions", err)
+		h.HandleErrorWithCode(w, http.StatusInternalServerError, "error getting permissions", err)
 		return
 	}
 
 	if err = h.incidentService.RemoveReminderPost(incidentID); err != nil {
 		h.log.Errorf("reminderButtonDismiss: error removing reminder for channelID: %s; error: %s", requestData.ChannelId, err.Error())
-		HandleErrorWithCode(w, http.StatusBadRequest, "error removing reminder", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "error removing reminder", err)
 		return
 	}
 
@@ -904,7 +915,7 @@ func (h *IncidentHandler) removeTimelineEvent(w http.ResponseWriter, r *http.Req
 	eventID := vars["eventID"]
 
 	if err := h.incidentService.RemoveTimelineEvent(id, userID, eventID); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -929,18 +940,18 @@ func (h *IncidentHandler) getChecklistAutocompleteItem(w http.ResponseWriter, r 
 
 	incidentID, err := h.incidentService.GetIncidentIDForChannel(channelID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if err = permissions.ViewIncidentFromChannelID(userID, channelID, h.pluginAPI); err != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions", err)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions", err)
 		return
 	}
 
 	data, err := h.incidentService.GetChecklistItemAutocomplete(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -954,18 +965,18 @@ func (h *IncidentHandler) getChecklistAutocomplete(w http.ResponseWriter, r *htt
 
 	incidentID, err := h.incidentService.GetIncidentIDForChannel(channelID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if err = permissions.ViewIncidentFromChannelID(userID, channelID, h.pluginAPI); err != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions", err)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions", err)
 		return
 	}
 
 	data, err := h.incidentService.GetChecklistAutocomplete(incidentID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -977,12 +988,12 @@ func (h *IncidentHandler) itemSetState(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 	itemNum, err := strconv.Atoi(vars["item"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
 		return
 	}
 	userID := r.Header.Get("Mattermost-User-ID")
@@ -991,17 +1002,17 @@ func (h *IncidentHandler) itemSetState(w http.ResponseWriter, r *http.Request) {
 		NewState string `json:"new_state"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal", err)
 		return
 	}
 
 	if !playbook.IsValidChecklistItemState(params.NewState) {
-		HandleErrorWithCode(w, http.StatusBadRequest, "bad parameter new state", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "bad parameter new state", nil)
 		return
 	}
 
 	if err := h.incidentService.ModifyCheckedState(id, userID, params.NewState, checklistNum, itemNum); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1013,12 +1024,12 @@ func (h *IncidentHandler) itemSetAssignee(w http.ResponseWriter, r *http.Request
 	id := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 	itemNum, err := strconv.Atoi(vars["item"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
 		return
 	}
 	userID := r.Header.Get("Mattermost-User-ID")
@@ -1027,12 +1038,12 @@ func (h *IncidentHandler) itemSetAssignee(w http.ResponseWriter, r *http.Request
 		AssigneeID string `json:"assignee_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal", err)
 		return
 	}
 
 	if err := h.incidentService.SetAssignee(id, userID, params.AssigneeID, checklistNum, itemNum); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1044,19 +1055,19 @@ func (h *IncidentHandler) itemRun(w http.ResponseWriter, r *http.Request) {
 	incidentID := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 	itemNum, err := strconv.Atoi(vars["item"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
 		return
 	}
 	userID := r.Header.Get("Mattermost-User-ID")
 
 	triggerID, err := h.incidentService.RunChecklistItemSlashCommand(incidentID, userID, checklistNum, itemNum)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1068,26 +1079,26 @@ func (h *IncidentHandler) addChecklistItem(w http.ResponseWriter, r *http.Reques
 	id := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 	userID := r.Header.Get("Mattermost-User-ID")
 
 	var checklistItem playbook.ChecklistItem
 	if err := json.NewDecoder(r.Body).Decode(&checklistItem); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode ChecklistItem", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode ChecklistItem", err)
 		return
 	}
 
 	checklistItem.Title = strings.TrimSpace(checklistItem.Title)
 	if checklistItem.Title == "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "bad parameter: checklist item title",
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "bad parameter: checklist item title",
 			errors.New("checklist item title must not be blank"))
 		return
 	}
 
 	if err := h.incidentService.AddChecklistItem(id, userID, checklistNum, checklistItem); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1101,18 +1112,18 @@ func (h *IncidentHandler) addChecklistItemDialog(w http.ResponseWriter, r *http.
 	incidentID := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 
 	request := model.SubmitDialogRequestFromJson(r.Body)
 	if request == nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to decode SubmitDialogRequest", nil)
 		return
 	}
 
 	if userID != request.UserId {
-		HandleErrorWithCode(w, http.StatusBadRequest, "interactive dialog's userID must be the same as the requester's userID", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "interactive dialog's userID must be the same as the requester's userID", nil)
 		return
 	}
 
@@ -1131,13 +1142,13 @@ func (h *IncidentHandler) addChecklistItemDialog(w http.ResponseWriter, r *http.
 
 	checklistItem.Title = strings.TrimSpace(checklistItem.Title)
 	if checklistItem.Title == "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "bad parameter: checklist item title",
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "bad parameter: checklist item title",
 			errors.New("checklist item title must not be blank"))
 		return
 	}
 
 	if err := h.incidentService.AddChecklistItem(incidentID, userID, checklistNum, checklistItem); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1150,18 +1161,18 @@ func (h *IncidentHandler) itemDelete(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 	itemNum, err := strconv.Atoi(vars["item"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
 		return
 	}
 	userID := r.Header.Get("Mattermost-User-ID")
 
 	if err := h.incidentService.RemoveChecklistItem(id, userID, checklistNum, itemNum); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1173,12 +1184,12 @@ func (h *IncidentHandler) itemEdit(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 	itemNum, err := strconv.Atoi(vars["item"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse item", err)
 		return
 	}
 	userID := r.Header.Get("Mattermost-User-ID")
@@ -1189,12 +1200,12 @@ func (h *IncidentHandler) itemEdit(w http.ResponseWriter, r *http.Request) {
 		Description string `json:"description"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal edit params state", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal edit params state", err)
 		return
 	}
 
 	if err := h.incidentService.EditChecklistItem(id, userID, checklistNum, itemNum, params.Title, params.Command, params.Description); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1206,7 +1217,7 @@ func (h *IncidentHandler) reorderChecklist(w http.ResponseWriter, r *http.Reques
 	id := vars["id"]
 	checklistNum, err := strconv.Atoi(vars["checklist"])
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to parse checklist", err)
 		return
 	}
 	userID := r.Header.Get("Mattermost-User-ID")
@@ -1216,12 +1227,12 @@ func (h *IncidentHandler) reorderChecklist(w http.ResponseWriter, r *http.Reques
 		NewLocation int `json:"new_location"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&modificationParams); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal edit params", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "failed to unmarshal edit params", err)
 		return
 	}
 
 	if err := h.incidentService.MoveChecklistItem(id, userID, checklistNum, modificationParams.ItemNum, modificationParams.NewLocation); err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1239,18 +1250,18 @@ func (h *IncidentHandler) telemetryForIncident(w http.ResponseWriter, r *http.Re
 		Action string `json:"action"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode post body", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode post body", err)
 		return
 	}
 
 	if params.Action == "" {
-		HandleError(w, errors.New("must provide action"))
+		h.HandleError(w, errors.New("must provide action"))
 		return
 	}
 
 	incdnt, err := h.incidentService.GetIncident(id)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -1283,12 +1294,12 @@ func (h *IncidentHandler) updateRetrospective(w http.ResponseWriter, r *http.Req
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&retroUpdate); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode payload", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode payload", err)
 		return
 	}
 
 	if err := h.incidentService.UpdateRetrospective(incidentID, userID, retroUpdate.Retrospective); err != nil {
-		HandleErrorWithCode(w, http.StatusInternalServerError, "unable to update retrospective", err)
+		h.HandleErrorWithCode(w, http.StatusInternalServerError, "unable to update retrospective", err)
 		return
 	}
 
@@ -1301,7 +1312,7 @@ func (h *IncidentHandler) publishRetrospective(w http.ResponseWriter, r *http.Re
 	userID := r.Header.Get("Mattermost-User-ID")
 
 	if err := h.incidentService.PublishRetrospective(incidentID, userID); err != nil {
-		HandleErrorWithCode(w, http.StatusInternalServerError, "unable to publish retrospective", err)
+		h.HandleErrorWithCode(w, http.StatusInternalServerError, "unable to publish retrospective", err)
 		return
 	}
 

--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -64,9 +64,9 @@ func TestIncidents(t *testing.T) {
 		configService = mock_config.NewMockService(mockCtrl)
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
-		handler = NewHandler(client, configService)
 		poster = mock_poster.NewMockPoster(mockCtrl)
 		logger = mock_poster.NewMockLogger(mockCtrl)
+		handler = NewHandler(client, configService, logger)
 		playbookService = mock_playbook.NewMockService(mockCtrl)
 		incidentService = mock_incident.NewMockService(mockCtrl)
 		telemetryService = &telemetry.NoopTelemetry{}
@@ -136,6 +136,7 @@ func TestIncidents(t *testing.T) {
 			})
 
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
@@ -423,6 +424,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("create incident from dialog - dialog request userID doesn't match requester's id", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
@@ -479,6 +481,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("create valid incident with missing playbookID from dialog", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		dialogRequest := model.SubmitDialogRequest{
 			TeamId: "testTeamID",
@@ -514,6 +517,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("create incident from dialog -- user does not have permission for the original postID's channel", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
@@ -562,6 +566,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("create incident from dialog -- user is not a member of the playbook", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		withid := playbook.Playbook{
 			ID:                   "playbookid1",
@@ -750,6 +755,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("create invalid incident - missing commander", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			TeamID: "testTeamID",
@@ -771,6 +777,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("create invalid incident - missing team", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			CommanderUserID: "testUserID",
@@ -790,6 +797,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("create invalid incident - missing name", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			CommanderUserID: "testUserID",
@@ -841,6 +849,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("get incident by channel id - not found", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 		userID := "testUserID"
 
 		testIncident := incident.Incident{
@@ -866,6 +875,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("get incident by channel id - not authorized", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			ID:              "incidentID",
@@ -1311,6 +1321,7 @@ func TestIncidents(t *testing.T) {
 
 	t.Run("get empty list of incidents", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 		setDefaultExpectations(t)
 
 		pluginAPI.On("HasPermissionToTeam", mock.Anything, mock.Anything, model.PERMISSION_VIEW_TEAM).Return(false)
@@ -1349,6 +1360,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("checklist autocomplete for a channel without permission to view", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			ID:              "incidentID",
@@ -1408,6 +1420,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("update incident status, bad status", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			ID:              "incidentID",
@@ -1430,6 +1443,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("update incident status, no permission to post", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			ID:              "incidentID",
@@ -1452,6 +1466,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("update incident status, message empty", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			ID:              "incidentID",
@@ -1474,6 +1489,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("update incident status, status empty", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			ID:              "incidentID",
@@ -1496,6 +1512,7 @@ func TestIncidents(t *testing.T) {
 	t.Run("update incident status, description empty", func(t *testing.T) {
 		reset(t)
 		setDefaultExpectations(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		testIncident := incident.Incident{
 			ID:              "incidentID",

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -58,42 +58,53 @@ func NewPlaybookHandler(router *mux.Router, playbookService playbook.Service, ap
 	return handler
 }
 
+// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
+func (h *PlaybookHandler) HandleError(w http.ResponseWriter, internalErr error) {
+	h.HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
+}
+
+// HandleErrorWithCode logs the internal error and sends the public facing error
+// message as JSON in a response with the provided code.
+func (h *PlaybookHandler) HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
+	HandleErrorWithCode(h.log, w, code, publicErrorMsg, internalErr)
+}
+
 func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
 
 	var pbook playbook.Playbook
 	if err := json.NewDecoder(r.Body).Decode(&pbook); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook", err)
 		return
 	}
 
 	if pbook.ID != "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "Playbook given already has ID", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Playbook given already has ID", nil)
 		return
 	}
 
 	if err := permissions.CreatePlaybook(userID, pbook, h.config, h.pluginAPI); err != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
 		return
 	}
 
 	if pbook.WebhookOnCreationEnabled {
 		url, err := url.ParseRequestURI(pbook.WebhookOnCreationURL)
 		if err != nil {
-			HandleErrorWithCode(w, http.StatusBadRequest, "invalid creation webhook URL", err)
+			h.HandleErrorWithCode(w, http.StatusBadRequest, "invalid creation webhook URL", err)
 			return
 		}
 
 		if url.Scheme != "http" && url.Scheme != "https" {
 			msg := fmt.Sprintf("protocol in creation webhook URL is %s; only HTTP and HTTPS are accepted", url.Scheme)
-			HandleErrorWithCode(w, http.StatusBadRequest, msg, errors.Errorf(msg))
+			h.HandleErrorWithCode(w, http.StatusBadRequest, msg, errors.Errorf(msg))
 			return
 		}
 	}
 
 	id, err := h.playbookService.Create(pbook, userID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -112,12 +123,12 @@ func (h *PlaybookHandler) getPlaybook(w http.ResponseWriter, r *http.Request) {
 
 	pbook, err := h.playbookService.Get(vars["id"])
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if err := permissions.PlaybookAccess(userID, pbook, h.pluginAPI); err != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
 		return
 	}
 
@@ -129,7 +140,7 @@ func (h *PlaybookHandler) updatePlaybook(w http.ResponseWriter, r *http.Request)
 	userID := r.Header.Get("Mattermost-User-ID")
 	var pbook playbook.Playbook
 	if err := json.NewDecoder(r.Body).Decode(&pbook); err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook", err)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode playbook", err)
 		return
 	}
 
@@ -138,37 +149,37 @@ func (h *PlaybookHandler) updatePlaybook(w http.ResponseWriter, r *http.Request)
 
 	oldPlaybook, err := h.playbookService.Get(vars["id"])
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if err3 := permissions.PlaybookModify(userID, pbook, oldPlaybook, h.pluginAPI); err3 != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err3)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err3)
 		return
 	}
 
 	if err4 := doPlaybookModificationChecks(&pbook, userID, h.pluginAPI); err4 != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err4)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err4)
 		return
 	}
 
 	if pbook.WebhookOnCreationEnabled {
 		url, err2 := url.ParseRequestURI(pbook.WebhookOnCreationURL)
 		if err2 != nil {
-			HandleErrorWithCode(w, http.StatusBadRequest, "invalid creation webhook URL", err2)
+			h.HandleErrorWithCode(w, http.StatusBadRequest, "invalid creation webhook URL", err2)
 			return
 		}
 
 		if url.Scheme != "http" && url.Scheme != "https" {
 			msg := fmt.Sprintf("protocol in creation webhook URL is %s; only HTTP and HTTPS are accepted", url.Scheme)
-			HandleErrorWithCode(w, http.StatusBadRequest, msg, errors.Errorf(msg))
+			h.HandleErrorWithCode(w, http.StatusBadRequest, msg, errors.Errorf(msg))
 			return
 		}
 	}
 
 	err = h.playbookService.Update(pbook, userID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -228,18 +239,18 @@ func (h *PlaybookHandler) deletePlaybook(w http.ResponseWriter, r *http.Request)
 
 	playbookToDelete, err := h.playbookService.Get(vars["id"])
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
 	if err2 := permissions.PlaybookAccess(userID, playbookToDelete, h.pluginAPI); err2 != nil {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err2)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err2)
 		return
 	}
 
 	err = h.playbookService.Delete(playbookToDelete, userID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -252,18 +263,18 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	userID := r.Header.Get("Mattermost-User-ID")
 	opts, err := parseGetPlaybooksOptions(r.URL)
 	if err != nil {
-		HandleErrorWithCode(w, http.StatusBadRequest, fmt.Sprintf("failed to get playbooks: %s", err.Error()), nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, fmt.Sprintf("failed to get playbooks: %s", err.Error()), nil)
 		return
 	}
 	memberOnly, _ := strconv.ParseBool(params.Get("member_only"))
 
 	if teamID == "" {
-		HandleErrorWithCode(w, http.StatusBadRequest, "Provide a team ID", nil)
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "Provide a team ID", nil)
 		return
 	}
 
 	if !permissions.CanViewTeam(userID, teamID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
 			"userID %s does not have permission to get playbooks on teamID %s",
 			userID,
 			teamID,
@@ -273,10 +284,10 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 
 	// Exclude guest users
 	if isGuest, errg := permissions.IsGuest(userID, h.pluginAPI); errg != nil {
-		HandleError(w, errg)
+		h.HandleError(w, errg)
 		return
 	} else if isGuest {
-		HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", errors.Errorf(
 			"userID %s does not have permission to get playbooks on teamID %s because they are a guest",
 			userID,
 			teamID,
@@ -293,7 +304,7 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 
 	playbookResults, err := h.playbookService.GetPlaybooksForTeam(requesterInfo, teamID, opts)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -306,7 +317,7 @@ func (h *PlaybookHandler) getPlaybooksAutoComplete(w http.ResponseWriter, r *htt
 	userID := r.Header.Get("Mattermost-User-ID")
 
 	if !permissions.CanViewTeam(userID, teamID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions to view team", nil)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions to view team", nil)
 		return
 	}
 
@@ -319,7 +330,7 @@ func (h *PlaybookHandler) getPlaybooksAutoComplete(w http.ResponseWriter, r *htt
 
 	playbooksResult, err := h.playbookService.GetPlaybooksForTeam(requesterInfo, teamID, playbook.Options{})
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 
@@ -341,13 +352,13 @@ func (h *PlaybookHandler) getPlaybookCount(w http.ResponseWriter, r *http.Reques
 	userID := r.Header.Get("Mattermost-User-ID")
 
 	if !permissions.CanViewTeam(userID, teamID, h.pluginAPI) {
-		HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions to view team", nil)
+		h.HandleErrorWithCode(w, http.StatusForbidden, "user does not have permissions to view team", nil)
 		return
 	}
 
 	count, err := h.playbookService.GetNumPlaybooksForTeam(teamID)
 	if err != nil {
-		HandleError(w, err)
+		h.HandleError(w, err)
 		return
 	}
 

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -21,6 +21,7 @@ import (
 
 // PlaybookHandler is the API handler.
 type PlaybookHandler struct {
+	*ErrorHandler
 	playbookService playbook.Service
 	pluginAPI       *pluginapi.Client
 	log             bot.Logger
@@ -32,6 +33,7 @@ const SettingsKey = "global_settings"
 // NewPlaybookHandler returns a new playbook api handler
 func NewPlaybookHandler(router *mux.Router, playbookService playbook.Service, api *pluginapi.Client, log bot.Logger, configService config.Service) *PlaybookHandler {
 	handler := &PlaybookHandler{
+		ErrorHandler:    &ErrorHandler{log: log},
 		playbookService: playbookService,
 		pluginAPI:       api,
 		log:             log,
@@ -56,17 +58,6 @@ func NewPlaybookHandler(router *mux.Router, playbookService playbook.Service, ap
 	playbookRouter.HandleFunc("", handler.deletePlaybook).Methods(http.MethodDelete)
 
 	return handler
-}
-
-// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
-func (h *PlaybookHandler) HandleError(w http.ResponseWriter, internalErr error) {
-	h.HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
-}
-
-// HandleErrorWithCode logs the internal error and sends the public facing error
-// message as JSON in a response with the provided code.
-func (h *PlaybookHandler) HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
-	HandleErrorWithCode(h.log, w, code, publicErrorMsg, internalErr)
 }
 
 func (h *PlaybookHandler) createPlaybook(w http.ResponseWriter, r *http.Request) {

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -141,7 +141,8 @@ func TestPlaybooks(t *testing.T) {
 		configService = mock_config.NewMockService(mockCtrl)
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
-		handler = NewHandler(client, configService)
+		logger = mock_poster.NewMockLogger(mockCtrl)
+		handler = NewHandler(client, configService, logger)
 		playbookService = mock_playbook.NewMockService(mockCtrl)
 		logger = mock_poster.NewMockLogger(mockCtrl)
 		poster = mock_poster.NewMockPoster(mockCtrl)
@@ -166,7 +167,8 @@ func TestPlaybooks(t *testing.T) {
 		configService = mock_config.NewMockService(mockCtrl)
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
-		handler = NewHandler(client, configService)
+		logger = mock_poster.NewMockLogger(mockCtrl)
+		handler = NewHandler(client, configService, logger)
 		playbookService = mock_playbook.NewMockService(mockCtrl)
 		logger = mock_poster.NewMockLogger(mockCtrl)
 		poster = mock_poster.NewMockPoster(mockCtrl)
@@ -219,6 +221,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("create playbook, as guest", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		playbookService.EXPECT().
 			Create(playbooktest, "testuserid").
@@ -241,6 +244,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("create playbook, no permissions to broadcast channel", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 		broadcastChannelID := model.NewId()
 
 		playbookService.EXPECT().
@@ -409,6 +413,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("create playbook with invited users and groups, group disallowing mention", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		pbook := playbook.Playbook{
 			Title:  "My Playbook",
@@ -532,6 +537,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("get playbooks, as guest", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		playbookResult := struct {
 			TotalCount int                 `json:"total_count"`
@@ -636,6 +642,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("update playbook but no permissions in broadcast channel", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		playbookService.EXPECT().
 			Get("testplaybookid").
@@ -878,6 +885,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("delete playbook no team permission", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		playbookService.EXPECT().
 			Get("testplaybookid").
@@ -892,6 +900,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("create playbook no team permission", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		pluginAPI.On("HasPermissionToTeam", "testuserid", "testteamid", model.PERMISSION_VIEW_TEAM).Return(false)
 		pluginAPI.On("GetUser", "testuserid").Return(&model.User{}, nil)
@@ -909,6 +918,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("get playbook no team permission", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		playbookService.EXPECT().
 			Get("testplaybookid").
@@ -924,6 +934,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("get playbooks no team permission", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		pluginAPI.On("HasPermissionToTeam", "testuserid", "testteamid", model.PERMISSION_VIEW_TEAM).Return(false)
 
@@ -934,6 +945,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("update playbooks no team permission", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		playbookService.EXPECT().
 			Get("testplaybookid").
@@ -964,6 +976,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("get playbook by non-member", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 		mattermostUserID = "unknownMember"
 
 		pluginAPI.On("HasPermissionToTeam", "unknownMember", "testteamid", model.PERMISSION_VIEW_TEAM).Return(true)
@@ -1004,6 +1017,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("update playbook by non-member", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 		mattermostUserID = "unknownMember"
 
 		playbookService.EXPECT().
@@ -1053,6 +1067,7 @@ func TestPlaybooks(t *testing.T) {
 
 	t.Run("delete playbook by non-member", func(t *testing.T) {
 		reset(t)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 		mattermostUserID = "unknownMember"
 
 		playbookService.EXPECT().
@@ -1233,7 +1248,8 @@ func TestSortingPlaybooks(t *testing.T) {
 		configService = mock_config.NewMockService(mockCtrl)
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
-		handler = NewHandler(client, configService)
+		logger = mock_poster.NewMockLogger(mockCtrl)
+		handler = NewHandler(client, configService, logger)
 		playbookService = mock_playbook.NewMockService(mockCtrl)
 		logger = mock_poster.NewMockLogger(mockCtrl)
 		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger, configService)
@@ -1328,6 +1344,10 @@ func TestSortingPlaybooks(t *testing.T) {
 	for _, data := range testData {
 		t.Run(data.testName, func(t *testing.T) {
 			reset(t)
+
+			if data.expectedErr != nil {
+				logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
+			}
 
 			playbookResult := struct {
 				TotalCount int                 `json:"total_count"`
@@ -1438,7 +1458,7 @@ func TestPagingPlaybooks(t *testing.T) {
 		pluginAPI = &plugintest.API{}
 		client = pluginapi.NewClient(pluginAPI)
 		logger = mock_poster.NewMockLogger(mockCtrl)
-		handler = NewHandler(client, configService)
+		handler = NewHandler(client, configService, logger)
 		playbookService = mock_playbook.NewMockService(mockCtrl)
 		NewPlaybookHandler(handler.APIRouter, playbookService, client, logger, configService)
 
@@ -1575,6 +1595,10 @@ func TestPagingPlaybooks(t *testing.T) {
 	for _, data := range testData {
 		t.Run(data.testName, func(t *testing.T) {
 			reset(t)
+
+			if data.expectedErr != nil {
+				logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
+			}
 
 			playbookService.EXPECT().
 				GetPlaybooksForTeam(

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -14,6 +14,7 @@ import (
 )
 
 type StatsHandler struct {
+	*ErrorHandler
 	pluginAPI  *pluginapi.Client
 	log        bot.Logger
 	statsStore *sqlstore.StatsStore
@@ -21,9 +22,10 @@ type StatsHandler struct {
 
 func NewStatsHandler(router *mux.Router, api *pluginapi.Client, log bot.Logger, statsStore *sqlstore.StatsStore, config config.Service) *StatsHandler {
 	handler := &StatsHandler{
-		pluginAPI:  api,
-		log:        log,
-		statsStore: statsStore,
+		ErrorHandler: &ErrorHandler{log: log},
+		pluginAPI:    api,
+		log:          log,
+		statsStore:   statsStore,
 	}
 
 	e20Middleware := E20LicenseRequired{config}
@@ -56,17 +58,6 @@ func parseStatsFilters(u *url.URL) (*sqlstore.StatsFilters, error) {
 	return &sqlstore.StatsFilters{
 		TeamID: teamID,
 	}, nil
-}
-
-// HandleError logs the internal error and sends a generic error as JSON in a 500 response.
-func (h *StatsHandler) HandleError(w http.ResponseWriter, internalErr error) {
-	h.HandleErrorWithCode(w, http.StatusInternalServerError, "An internal error has occurred. Check app server logs for details.", internalErr)
-}
-
-// HandleErrorWithCode logs the internal error and sends the public facing error
-// message as JSON in a response with the provided code.
-func (h *StatsHandler) HandleErrorWithCode(w http.ResponseWriter, code int, publicErrorMsg string, internalErr error) {
-	HandleErrorWithCode(h.log, w, code, publicErrorMsg, internalErr)
 }
 
 func (h *StatsHandler) stats(w http.ResponseWriter, r *http.Request) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -133,7 +133,7 @@ func (p *Plugin) OnActivate() error {
 	playbookStore := sqlstore.NewPlaybookStore(apiClient, p.bot, sqlStore)
 	statsStore := sqlstore.NewStatsStore(apiClient, p.bot, sqlStore)
 
-	p.handler = api.NewHandler(pluginAPIClient, p.config)
+	p.handler = api.NewHandler(pluginAPIClient, p.config, p.bot)
 	p.bot = bot.New(pluginAPIClient, p.config.GetConfiguration().BotUserID, p.config)
 
 	scheduler := cluster.GetJobOnceScheduler(p.API)


### PR DESCRIPTION
#### Summary
- the endpoint needed something to send back, because it was a `doPost` -> `doFetchWithResponse` call on the client.
- while investigating, found that the errors logged through logrus are not great--they don't conform to the way the server logs errors, and so they aren't coded correctly. The second commit fixes that.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35600

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
[ ] ~~Telemetry updated~~
[ ] ~~Gated by experimental feature flag~~
[x] Unit tests updated
