### PR TITLE
MM-35496 - Playbook prompts for save despite no changes

### DIFF
--- a/webapp/src/components/backstage/step_edit.tsx
+++ b/webapp/src/components/backstage/step_edit.tsx
@@ -22,7 +22,7 @@ const Container = styled.div`
 
 const StepLine = styled.div`
     display: flex;
-    direction: row;
+    flex-direction: row;
 `;
 
 const StepEdit: FC<StepEditProps> = (props: StepEditProps) => {
@@ -35,17 +35,29 @@ const StepEdit: FC<StepEditProps> = (props: StepEditProps) => {
             <StepLine>
                 <ChecklistItemTitle
                     title={props.step.title}
-                    setTitle={(title) => submit({...props.step, title})}
+                    setTitle={(title) => {
+                        if (props.step.title !== title) {
+                            submit({...props.step, title});
+                        }
+                    }}
                 />
                 <ChecklistItemCommand
                     command={props.step.command}
-                    setCommand={(command) => submit({...props.step, command})}
+                    setCommand={(command) => {
+                        if (props.step.command !== command) {
+                            submit({...props.step, command});
+                        }
+                    }}
                     autocompleteOnBottom={props.autocompleteOnBottom}
                 />
             </StepLine>
             <ChecklistItemDescription
                 description={props.step.description}
-                setDescription={(description) => submit({...props.step, description})}
+                setDescription={(description) => {
+                    if (props.step.description !== description) {
+                        submit({...props.step, description});
+                    }
+                }}
             />
         </Container>
     );


### PR DESCRIPTION
#### Summary
- Just pressing back doesn't prompt me for a save, so I'm not exactly sure what the customer is referring to.
- But maybe they meant: clicking a step title/command/description text box, and then clicking out (without making any changes) causes the prompt for save. Which I /can/ reproduce. So I'm fixing that. 
- Clicking on textareas (all the other larger inputs) and clicking back does not prompt for a save, so no need to change those.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35496
