### PR TITLE
MM-35605 - Fix for Playbooks can be closed without changes getting saved

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -191,14 +191,12 @@ const Backstage: FC = () => {
                         <PlaybookEdit
                             isNew={true}
                             currentTeam={currentTeam}
-                            onClose={goToPlaybooks}
                         />
                     </Route>
                     <Route path={`${match.url}/playbooks/:playbookId`}>
                         <PlaybookEdit
                             isNew={false}
                             currentTeam={currentTeam}
-                            onClose={goToPlaybooks}
                         />
                     </Route>
                     <Route path={`${match.url}/playbooks`}>

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {FC, useState, useEffect} from 'react';
-import {Redirect, useParams, useLocation} from 'react-router-dom';
+import {Redirect, useParams, useLocation, Prompt} from 'react-router-dom';
 import {useSelector, useDispatch} from 'react-redux';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -623,6 +623,10 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                 confirmButtonText={'Discard Changes'}
                 onConfirm={props.onClose}
                 onCancel={confirmCancel}
+            />
+            <Prompt
+                when={changesMade}
+                message={'Are you sure you want to discard your changes?'}
             />
         </OuterContainer>
     );

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -12,7 +12,6 @@ import {GlobalState} from 'mattermost-redux/types/store';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {Team} from 'mattermost-redux/types/teams';
 
-
 import {Tabs, TabsContent} from 'src/components/tabs';
 import {PresetTemplates} from 'src/components/backstage/template_selector';
 import {navigateToTeamPluginUrl, teamPluginErrorUrl} from 'src/browser_routing';

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {FC, useState, useEffect} from 'react';
-import {Redirect, useParams, useLocation, Prompt, useRouteMatch} from 'react-router-dom';
+import {Redirect, useParams, useLocation, Prompt} from 'react-router-dom';
 import {useSelector, useDispatch} from 'react-redux';
 import styled from 'styled-components';
 

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -2,25 +2,23 @@
 // See LICENSE.txt for license information.
 
 import React, {FC, useState, useEffect} from 'react';
-import {Redirect, useParams, useLocation, Prompt} from 'react-router-dom';
+import {Redirect, useParams, useLocation, Prompt, useRouteMatch} from 'react-router-dom';
 import {useSelector, useDispatch} from 'react-redux';
+import styled from 'styled-components';
 
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getProfilesInTeam, searchProfiles} from 'mattermost-redux/actions/users';
-
+import {GlobalState} from 'mattermost-redux/types/store';
+import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {Team} from 'mattermost-redux/types/teams';
 
-import styled from 'styled-components';
 
 import {Tabs, TabsContent} from 'src/components/tabs';
-
 import {PresetTemplates} from 'src/components/backstage/template_selector';
-
-import {teamPluginErrorUrl} from 'src/browser_routing';
+import {navigateToTeamPluginUrl, teamPluginErrorUrl} from 'src/browser_routing';
 import {Playbook, Checklist, emptyPlaybook, defaultMessageOnJoin} from 'src/types/playbook';
 import {savePlaybook, clientFetchPlaybook} from 'src/client';
 import {StagesAndStepsEdit} from 'src/components/backstage/stages_and_steps_edit';
-import ConfirmModal from 'src/components/widgets/confirmation_modal';
 import {ErrorPageTypes, TEMPLATE_TITLE_KEY, PROFILE_CHUNK_SIZE} from 'src/constants';
 import {PrimaryButton} from 'src/components/assets/buttons';
 import {BackstageNavbar, BackstageNavbarIcon} from 'src/components/backstage/backstage';
@@ -121,7 +119,6 @@ const OuterContainer = styled.div`
 interface Props {
     isNew: boolean;
     currentTeam: Team;
-    onClose: () => void;
 }
 
 interface URLParams {
@@ -167,10 +164,10 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
         member_ids: [currentUserId],
     });
     const [changesMade, setChangesMade] = useState(false);
-    const [confirmOpen, setConfirmOpen] = useState(false);
 
     const urlParams = useParams<URLParams>();
     const location = useLocation();
+    const currentTeam = useSelector<GlobalState, Team>(getCurrentTeam);
 
     const [fetchingState, setFetchingState] = useState(FetchingStateType.loading);
 
@@ -217,8 +214,8 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
 
     const onSave = async () => {
         await savePlaybook(setPlaybookDefaults(playbook));
-
-        props.onClose();
+        setChangesMade(false);
+        navigateToTeamPluginUrl(currentTeam.name, '/playbooks');
     };
 
     const updateChecklist = (newChecklist: Checklist[]) => {
@@ -240,18 +237,6 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
             title,
         });
         setChangesMade(true);
-    };
-
-    const confirmOrClose = () => {
-        if (changesMade) {
-            setConfirmOpen(true);
-        } else {
-            props.onClose();
-        }
-    };
-
-    const confirmCancel = () => {
-        setConfirmOpen(false);
     };
 
     const handlePublicChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -419,7 +404,7 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                 <BackstageNavbarIcon
                     data-testid='icon-arrow-left'
                     className='icon-arrow-left back-icon'
-                    onClick={confirmOrClose}
+                    onClick={() => navigateToTeamPluginUrl(currentTeam.name, '/playbooks')}
                 />
                 <EditableTexts>
                     <EditableTitleContainer>
@@ -616,14 +601,6 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                     </EditContent>
                 </EditView>
             </Container>
-            <ConfirmModal
-                show={confirmOpen}
-                title={'Confirm discard'}
-                message={'Are you sure you want to discard your changes?'}
-                confirmButtonText={'Discard Changes'}
-                onConfirm={props.onClose}
-                onCancel={confirmCancel}
-            />
             <Prompt
                 when={changesMade}
                 message={'Are you sure you want to discard your changes?'}

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -22,6 +22,7 @@ import {ErrorPageTypes, TEMPLATE_TITLE_KEY, PROFILE_CHUNK_SIZE} from 'src/consta
 import {PrimaryButton} from 'src/components/assets/buttons';
 import {BackstageNavbar, BackstageNavbarIcon} from 'src/components/backstage/backstage';
 import {AutomationSettings} from 'src/components/backstage/automation/settings';
+import RouteLeavingGuard from 'src/components/backstage/route_leaving_guard';
 
 import './playbook.scss';
 import EditableText from './editable_text';
@@ -151,6 +152,9 @@ const timerOptions = [
     {value: 14400, label: '4hr'},
     {value: 86400, label: '24hr'},
 ];
+
+// @ts-ignore
+const WebappUtils = window.WebappUtils;
 
 const PlaybookEdit: FC<Props> = (props: Props) => {
     const dispatch = useDispatch();
@@ -600,9 +604,9 @@ const PlaybookEdit: FC<Props> = (props: Props) => {
                     </EditContent>
                 </EditView>
             </Container>
-            <Prompt
-                when={changesMade}
-                message={'Are you sure you want to discard your changes?'}
+            <RouteLeavingGuard
+                navigate={(path) => WebappUtils.browserHistory.push(path)}
+                shouldBlockNavigation={() => changesMade}
             />
         </OuterContainer>
     );

--- a/webapp/src/components/backstage/route_leaving_guard.tsx
+++ b/webapp/src/components/backstage/route_leaving_guard.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect, useState} from 'react';
+import {Prompt} from 'react-router-dom';
+
+import ConfirmModal from 'src/components/widgets/confirmation_modal';
+
+interface Props {
+    when?: boolean | undefined;
+    navigate: (path: string) => void;
+    shouldBlockNavigation: (location: Location) => boolean;
+}
+
+// Credit to: https://michaelchan-13570.medium.com/using-react-router-v4-prompt-with-custom-modal-component-ca839f5faf39
+const RouteLeavingGuard = (props: Props) => {
+    const [modalVisible, setModalVisible] = useState(false);
+    const [lastLocation, setLastLocation] = useState<Location | null>(null);
+    const [confirmedNavigation, setConfirmedNavigation] = useState(false);
+
+    const closeModal = () => {
+        setModalVisible(false);
+    };
+
+    // @ts-ignore
+    const handleBlockedNavigation = (nextLocation: Location<unknown>): boolean => {
+        if (!confirmedNavigation && props.shouldBlockNavigation(nextLocation)) {
+            setModalVisible(true);
+            setLastLocation(nextLocation);
+            return false;
+        }
+        return true;
+    };
+
+    const handleConfirmNavigationClick = () => {
+        setModalVisible(false);
+        setConfirmedNavigation(true);
+    };
+
+    useEffect(() => {
+        if (confirmedNavigation && lastLocation) {
+            // Navigate to the previous blocked location with your navigate function
+            props.navigate(lastLocation.pathname);
+        }
+    }, [confirmedNavigation, lastLocation]);
+
+    return (
+        <>
+            <Prompt
+                when={props.when}
+                message={handleBlockedNavigation}
+            />
+            <ConfirmModal
+                show={modalVisible}
+                title={'Confirm discard'}
+                message={'Are you sure you want to discard your changes?'}
+                confirmButtonText={'Discard Changes'}
+                onConfirm={handleConfirmNavigationClick}
+                onCancel={closeModal}
+            />
+        </>
+    );
+};
+
+export default RouteLeavingGuard;


### PR DESCRIPTION
#### Summary
- Using react router's prompt (it's amazing)
- No need for manual confirmation dialog (but it's not as pretty)

Looks like:
![image](https://user-images.githubusercontent.com/1490756/118324089-92429880-b4cf-11eb-9ec6-23f8a332827e.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35605

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
[ ] ~~Telemetry updated~~
[ ] ~~Gated by experimental feature flag~~
[ ] ~~Unit tests updated~~
