### PR TITLE
MM-35889: Add telemetry for upgrade features

### DIFF
--- a/server/api/incidents_test.go
+++ b/server/api/incidents_test.go
@@ -28,7 +28,6 @@ import (
 	mock_incident "github.com/mattermost/mattermost-plugin-incident-collaboration/server/incident/mocks"
 	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/playbook"
 	mock_playbook "github.com/mattermost/mattermost-plugin-incident-collaboration/server/playbook/mocks"
-	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/telemetry"
 )
 
 func TestIncidents(t *testing.T) {
@@ -41,7 +40,6 @@ func TestIncidents(t *testing.T) {
 	var incidentService *mock_incident.MockService
 	var pluginAPI *plugintest.API
 	var client *pluginapi.Client
-	telemetryService := &telemetry.NoopTelemetry{}
 
 	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
 	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -69,8 +67,7 @@ func TestIncidents(t *testing.T) {
 		handler = NewHandler(client, configService, logger)
 		playbookService = mock_playbook.NewMockService(mockCtrl)
 		incidentService = mock_incident.NewMockService(mockCtrl)
-		telemetryService = &telemetry.NoopTelemetry{}
-		NewIncidentHandler(handler.APIRouter, incidentService, playbookService, client, poster, logger, telemetryService, configService)
+		NewIncidentHandler(handler.APIRouter, incidentService, playbookService, client, poster, logger, configService)
 	}
 
 	setDefaultExpectations := func(t *testing.T) {
@@ -788,8 +785,7 @@ func TestIncidents(t *testing.T) {
 		handler = NewHandler(client, configService, logger)
 		playbookService = mock_playbook.NewMockService(mockCtrl)
 		incidentService = mock_incident.NewMockService(mockCtrl)
-		telemetryService = &telemetry.NoopTelemetry{}
-		NewIncidentHandler(handler.APIRouter, incidentService, playbookService, client, poster, logger, telemetryService, configService)
+		NewIncidentHandler(handler.APIRouter, incidentService, playbookService, client, poster, logger, configService)
 
 		configService.EXPECT().
 			IsAtLeastE10Licensed().

--- a/server/api/telemetry.go
+++ b/server/api/telemetry.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/bot"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/config"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/incident"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/permissions"
+)
+
+// TelemetryHandler is the API handler.
+type TelemetryHandler struct {
+	*ErrorHandler
+	incidentService   incident.Service
+	incidentTelemetry incident.Telemetry
+	botTelemetry      bot.Telemetry
+	pluginAPI         *pluginapi.Client
+}
+
+// NewTelemetryHandler Creates a new Plugin API handler.
+func NewTelemetryHandler(router *mux.Router, incidentService incident.Service,
+	api *pluginapi.Client, log bot.Logger, incidentTelemetry incident.Telemetry, botTelemetry bot.Telemetry, configService config.Service) *TelemetryHandler {
+	handler := &TelemetryHandler{
+		ErrorHandler:      &ErrorHandler{log: log},
+		incidentService:   incidentService,
+		incidentTelemetry: incidentTelemetry,
+		botTelemetry:      botTelemetry,
+		pluginAPI:         api,
+	}
+
+	telemetryRouter := router.PathPrefix("/telemetry").Subrouter()
+
+	startTrialRouter := telemetryRouter.PathPrefix("/start-trial").Subrouter()
+	startTrialRouter.HandleFunc("", handler.startTrial).Methods(http.MethodPost)
+
+	incidentTelemetryRouterAuthorized := telemetryRouter.PathPrefix("/incident").Subrouter()
+	incidentTelemetryRouterAuthorized.Use(handler.checkViewPermissions)
+	incidentTelemetryRouterAuthorized.HandleFunc("/{id:[A-Za-z0-9]+}", handler.telemetryForIncident).Methods(http.MethodPost)
+
+	return handler
+}
+
+func (h *TelemetryHandler) checkViewPermissions(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		userID := r.Header.Get("Mattermost-User-ID")
+
+		incdnt, err := h.incidentService.GetIncident(vars["id"])
+		if err != nil {
+			h.HandleError(w, err)
+			return
+		}
+
+		if err := permissions.ViewIncidentFromChannelID(userID, incdnt.ChannelID, h.pluginAPI); err != nil {
+			if errors.Is(err, permissions.ErrNoPermissions) {
+				h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
+				return
+			}
+			h.HandleError(w, err)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+type TrackerPayload struct {
+	Action string `json:"action"`
+}
+
+// telemetryForIncident handles the /telemetry/incident/{id}?action=the_action endpoint. The frontend
+// can use this endpoint to track events that occur in the context of an incident
+func (h *TelemetryHandler) telemetryForIncident(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	var params TrackerPayload
+	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode post body", err)
+		return
+	}
+
+	if params.Action == "" {
+		h.HandleError(w, errors.New("must provide action"))
+		return
+	}
+
+	incdnt, err := h.incidentService.GetIncident(id)
+	if err != nil {
+		h.HandleError(w, err)
+		return
+	}
+
+	h.incidentTelemetry.FrontendTelemetryForIncident(incdnt, userID, params.Action)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *TelemetryHandler) startTrial(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	var params TrackerPayload
+	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode post body", err)
+		return
+	}
+
+	switch params.Action {
+	case "start_trial_to_view_timeline":
+		h.botTelemetry.StartTrialToViewTimeline(userID)
+	case "start_trial_to_add_message_to_timeline":
+		h.botTelemetry.StartTrialToAddMessageToTimeline(userID)
+	case "start_trial_to_create_playbook":
+		h.botTelemetry.StartTrialToCreatePlaybook(userID)
+	case "start_trial_to_restrict_playbook_creation":
+		h.botTelemetry.StartTrialToRestrictPlaybookCreation(userID)
+	case "start_trial_to_restrict_playbook_access":
+		h.botTelemetry.StartTrialToRestrictPlaybookAccess(userID)
+	default:
+		h.HandleError(w, errors.New("unknown action"))
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/bot/bot.go
+++ b/server/bot/bot.go
@@ -65,6 +65,11 @@ type Telemetry interface {
 	NotifyAdminsToCreatePlaybook(userID string)
 	NotifyAdminsToRestrictPlaybookCreation(userID string)
 	NotifyAdminsToRestrictPlaybookAccess(userID string)
+	StartTrialToViewTimeline(userID string)
+	StartTrialToAddMessageToTimeline(userID string)
+	StartTrialToCreatePlaybook(userID string)
+	StartTrialToRestrictPlaybookCreation(userID string)
+	StartTrialToRestrictPlaybookAccess(userID string)
 }
 
 // New creates a new bot poster/logger.

--- a/server/bot/bot.go
+++ b/server/bot/bot.go
@@ -14,6 +14,7 @@ type Bot struct {
 	pluginAPI     *pluginapi.Client
 	botUserID     string
 	logContext    LogContext
+	telemetry     Telemetry
 }
 
 // Logger interface - a logging system that will tee logs to a DM channel.
@@ -58,12 +59,21 @@ type Poster interface {
 	NotifyAdmins(message, authorUserID string, isTeamEdition bool) error
 }
 
+type Telemetry interface {
+	NotifyAdminsToViewTimeline(userID string)
+	NotifyAdminsToAddMessageToTimeline(userID string)
+	NotifyAdminsToCreatePlaybook(userID string)
+	NotifyAdminsToRestrictPlaybookCreation(userID string)
+	NotifyAdminsToRestrictPlaybookAccess(userID string)
+}
+
 // New creates a new bot poster/logger.
-func New(api *pluginapi.Client, botUserID string, configService config.Service) *Bot {
+func New(api *pluginapi.Client, botUserID string, configService config.Service, telemetry Telemetry) *Bot {
 	return &Bot{
 		pluginAPI:     api,
 		botUserID:     botUserID,
 		configService: configService,
+		telemetry:     telemetry,
 	}
 }
 
@@ -74,5 +84,6 @@ func (b *Bot) clone() *Bot {
 		pluginAPI:     b.pluginAPI,
 		botUserID:     b.botUserID,
 		logContext:    b.logContext.copyShallow(),
+		telemetry:     b.telemetry,
 	}
 }

--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -111,20 +111,20 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 	}
 
 	switch messageType {
-	case "playbook":
+	case "start_trial_to_create_playbook":
 		message = fmt.Sprintf("@%s requested access to create more playbooks in Incident Collaboration.", author.Username)
 		title = "Create multiple playbooks in Incident Collaboration with Mattermost Enterprise Edition E10"
 		text = "Playbooks are workflows that provide guidance through an incident. Each playbook can be customized and refined over time, to improve time to resolution. In Enterprise Edition E10 you can create an unlimited number of playbooks for your team.\n" + footer
 
-	case "message_to_timeline", "view_timeline":
+	case "start_trial_to_add_message_to_timeline", "start_trial_to_view_timeline":
 		message = fmt.Sprintf("@%s requested access to the timeline in Incident Collaboration.", author.Username)
 		title = "Keep all your incident events in one place with Mattermost Enterprise Edition E10"
 		text = "Your timeline lists all the events in your incident, separated by type. You can download your timeline and use it for your retrospectives to improve how you respond to incidents. Enterprise Edition E10 includes access to timeline features such as adding messages from within the incident channel.\n" + footer
-	case "playbook_granular_access":
+	case "start_trial_to_restrict_playbook_access":
 		message = fmt.Sprintf("@%s requested access to configure who can access specific playbooks in Incident Collaboration.", author.Username)
 		title = "Control who can access specific playbooks in Incident Collaboration with Mattermost Enterprise Edition E20"
 		text = "Playbooks are workflows that provide guidance through an incident. In Enterprise Edition E20 you can set playbook permissions for specific users or set a global permission to control which team members can create playbooks.\n" + footer
-	case "playbook_creation_restriction":
+	case "strat_trial_to_restrict_playbook_creation":
 		message = fmt.Sprintf("@%s requested access to configure who can create playbooks in Incident Collaboration.", author.Username)
 		title = "Control who can create playbooks in Incident Collaboration with Mattermost Enterprise Edition E20"
 		text = "Playbooks are workflows that provide guidance through an incident. In Enterprise Edition E20 you can set playbook permissions for specific users or set a global permission to control which team members can create playbooks.\n" + footer
@@ -173,15 +173,15 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 	}
 
 	switch messageType {
-	case "playbook":
+	case "start_trial_to_create_playbook":
 		b.telemetry.NotifyAdminsToCreatePlaybook(authorUserID)
-	case "view_timeline":
+	case "start_trial_to_view_timeline":
 		b.telemetry.NotifyAdminsToViewTimeline(authorUserID)
-	case "message_to_timeline":
+	case "start_trial_to_add_message_to_timeline":
 		b.telemetry.NotifyAdminsToAddMessageToTimeline(authorUserID)
-	case "playbook_granular_access":
+	case "start_trial_to_restrict_playbook_access":
 		b.telemetry.NotifyAdminsToRestrictPlaybookAccess(authorUserID)
-	case "playbook_creation_restriction":
+	case "start_trial_to_restrict_playbook_creation":
 		b.telemetry.NotifyAdminsToRestrictPlaybookCreation(authorUserID)
 	}
 

--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -172,6 +172,19 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 		}(admin.Id)
 	}
 
+	switch messageType {
+	case "playbook":
+		b.telemetry.NotifyAdminsToCreatePlaybook(authorUserID)
+	case "view_timeline":
+		b.telemetry.NotifyAdminsToViewTimeline(authorUserID)
+	case "message_to_timeline":
+		b.telemetry.NotifyAdminsToAddMessageToTimeline(authorUserID)
+	case "playbook_granular_access":
+		b.telemetry.NotifyAdminsToRestrictPlaybookAccess(authorUserID)
+	case "playbook_creation_restriction":
+		b.telemetry.NotifyAdminsToRestrictPlaybookCreation(authorUserID)
+	}
+
 	return nil
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -71,11 +71,10 @@ func (p *Plugin) OnActivate() error {
 		return errors.Wrapf(err, "failed save bot to config")
 	}
 
-	p.bot = bot.New(pluginAPIClient, botID, p.config)
-
 	var telemetryClient interface {
 		incident.Telemetry
 		playbook.Telemetry
+		bot.Telemetry
 		Enable() error
 		Disable() error
 	}
@@ -134,7 +133,7 @@ func (p *Plugin) OnActivate() error {
 	statsStore := sqlstore.NewStatsStore(apiClient, p.bot, sqlStore)
 
 	p.handler = api.NewHandler(pluginAPIClient, p.config, p.bot)
-	p.bot = bot.New(pluginAPIClient, p.config.GetConfiguration().BotUserID, p.config)
+	p.bot = bot.New(pluginAPIClient, p.config.GetConfiguration().BotUserID, p.config, telemetryClient)
 
 	scheduler := cluster.GetJobOnceScheduler(p.API)
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -170,11 +170,11 @@ func (p *Plugin) OnActivate() error {
 		pluginAPIClient,
 		p.bot,
 		p.bot,
-		telemetryClient,
 		p.config,
 	)
 	api.NewStatsHandler(p.handler.APIRouter, pluginAPIClient, p.bot, statsStore, p.config)
 	api.NewBotHandler(p.handler.APIRouter, pluginAPIClient, p.bot, p.bot, p.config)
+	api.NewTelemetryHandler(p.handler.APIRouter, p.incidentService, pluginAPIClient, p.bot, telemetryClient, telemetryClient, p.config)
 
 	isTestingEnabled := false
 	flag := p.API.GetConfig().ServiceSettings.EnableTesting

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -95,3 +95,28 @@ func (t *NoopTelemetry) UpdateRetrospective(incident *incident.Incident, userID 
 
 func (t *NoopTelemetry) PublishRetrospective(incident *incident.Incident, userID string) {
 }
+
+// NotifyAdminsToViewTimeline does nothing.
+func (t *NoopTelemetry) NotifyAdminsToViewTimeline(userID string) {
+
+}
+
+// NotifyAdminsToAddMessageToTimeline does nothing.
+func (t *NoopTelemetry) NotifyAdminsToAddMessageToTimeline(userID string) {
+
+}
+
+// NotifyAdminsToCreatePlaybook does nothing.
+func (t *NoopTelemetry) NotifyAdminsToCreatePlaybook(userID string) {
+
+}
+
+// NotifyAdminsToRestrictPlaybookCreation does nothing.
+func (t *NoopTelemetry) NotifyAdminsToRestrictPlaybookCreation(userID string) {
+
+}
+
+// NotifyAdminsToRestrictPlaybookAccess does nothing.
+func (t *NoopTelemetry) NotifyAdminsToRestrictPlaybookAccess(userID string) {
+
+}

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -96,6 +96,26 @@ func (t *NoopTelemetry) UpdateRetrospective(incident *incident.Incident, userID 
 func (t *NoopTelemetry) PublishRetrospective(incident *incident.Incident, userID string) {
 }
 
+// StartTrialToViewTimeline does nothing.
+func (t *NoopTelemetry) StartTrialToViewTimeline(userID string) {
+}
+
+// StartTrialToAddMessageToTimeline does nothing.
+func (t *NoopTelemetry) StartTrialToAddMessageToTimeline(userID string) {
+}
+
+// StartTrialToCreatePlaybook does nothing.
+func (t *NoopTelemetry) StartTrialToCreatePlaybook(userID string) {
+}
+
+// StartTrialToRestrictPlaybookCreation does nothing.
+func (t *NoopTelemetry) StartTrialToRestrictPlaybookCreation(userID string) {
+}
+
+// StartTrialToRestrictPlaybookAccess does nothing.
+func (t *NoopTelemetry) StartTrialToRestrictPlaybookAccess(userID string) {
+}
+
 // NotifyAdminsToViewTimeline does nothing.
 func (t *NoopTelemetry) NotifyAdminsToViewTimeline(userID string) {
 

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -49,6 +49,13 @@ const (
 	actionDelete  = "delete"
 
 	eventFrontend = "frontend"
+
+	eventNotifyAdmins                            = "notify_admins"
+	actionNotifyAdminsToViewTimeline             = "notify_admins_to_view_timeline"
+	actionNotifyAdminsToAddMessageToTimeline     = "notify_admins_to_add_message_to_timeline"
+	actionNotifyAdminsToCreatePlaybook           = "notify_admins_to_create_playbook"
+	actionNotifyAdminsToRestrictPlaybookCreation = "notify_admins_to_restrict_playbook_creation"
+	actionNotifyAdminsToRestrictPlaybookAccess   = "notify_admins_to_restrict_playbook_access"
 )
 
 // NewRudder builds a new RudderTelemetry client that will send the events to
@@ -327,6 +334,47 @@ func (t *RudderTelemetry) DeletePlaybook(pbook playbook.Playbook, userID string)
 	properties := playbookProperties(pbook, userID)
 	properties["Action"] = actionDelete
 	t.track(eventPlaybook, properties)
+}
+
+func commonProperties(userID string) map[string]interface{} {
+	return map[string]interface{}{
+		"UserActualID": userID,
+	}
+}
+
+func (t *RudderTelemetry) NotifyAdminsToViewTimeline(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionNotifyAdminsToViewTimeline
+	t.track(eventNotifyAdmins, properties)
+
+}
+
+func (t *RudderTelemetry) NotifyAdminsToAddMessageToTimeline(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionNotifyAdminsToAddMessageToTimeline
+	t.track(eventNotifyAdmins, properties)
+
+}
+
+func (t *RudderTelemetry) NotifyAdminsToCreatePlaybook(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionNotifyAdminsToCreatePlaybook
+	t.track(eventNotifyAdmins, properties)
+
+}
+
+func (t *RudderTelemetry) NotifyAdminsToRestrictPlaybookCreation(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionNotifyAdminsToRestrictPlaybookCreation
+	t.track(eventNotifyAdmins, properties)
+
+}
+
+func (t *RudderTelemetry) NotifyAdminsToRestrictPlaybookAccess(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionNotifyAdminsToRestrictPlaybookAccess
+	t.track(eventNotifyAdmins, properties)
+
 }
 
 // Enable creates a new client to track all future events. It does nothing if

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -56,6 +56,13 @@ const (
 	actionNotifyAdminsToCreatePlaybook           = "notify_admins_to_create_playbook"
 	actionNotifyAdminsToRestrictPlaybookCreation = "notify_admins_to_restrict_playbook_creation"
 	actionNotifyAdminsToRestrictPlaybookAccess   = "notify_admins_to_restrict_playbook_access"
+
+	eventStartTrial                            = "start_trial"
+	actionStartTrialToViewTimeline             = "start_trial_to_view_timeline"
+	actionStartTrialToAddMessageToTimeline     = "start_trial_to_add_message_to_timeline"
+	actionStartTrialToCreatePlaybook           = "start_trial_to_create_playbook"
+	actionStartTrialToRestrictPlaybookCreation = "start_trial_to_restrict_playbook_creation"
+	actionStartTrialToRestrictPlaybookAccess   = "start_trial_to_restrict_playbook_access"
 )
 
 // NewRudder builds a new RudderTelemetry client that will send the events to
@@ -340,6 +347,36 @@ func commonProperties(userID string) map[string]interface{} {
 	return map[string]interface{}{
 		"UserActualID": userID,
 	}
+}
+
+func (t *RudderTelemetry) StartTrialToViewTimeline(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionStartTrialToViewTimeline
+	t.track(eventStartTrial, properties)
+}
+
+func (t *RudderTelemetry) StartTrialToAddMessageToTimeline(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionStartTrialToAddMessageToTimeline
+	t.track(eventStartTrial, properties)
+}
+
+func (t *RudderTelemetry) StartTrialToCreatePlaybook(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionStartTrialToCreatePlaybook
+	t.track(eventStartTrial, properties)
+}
+
+func (t *RudderTelemetry) StartTrialToRestrictPlaybookCreation(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionStartTrialToRestrictPlaybookCreation
+	t.track(eventStartTrial, properties)
+}
+
+func (t *RudderTelemetry) StartTrialToRestrictPlaybookAccess(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionStartTrialToRestrictPlaybookAccess
+	t.track(eventStartTrial, properties)
 }
 
 func (t *RudderTelemetry) NotifyAdminsToViewTimeline(userID string) {

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -338,7 +338,16 @@ export function exportChannelUrl(channelId: string) {
     return `${exportPluginUrl}/export${queryParams}`;
 }
 
-export const requestTrialLicense = async (users: number) => {
+export async function trackRequestTrialLicense(action: string) {
+    await doFetchWithoutResponse(`${apiUrl}/telemetry/start-trial`, {
+        method: 'POST',
+        body: JSON.stringify({action}),
+    });
+}
+
+export const requestTrialLicense = async (users: number, action: string) => {
+    trackRequestTrialLicense(action);
+
     try {
         const response = await Client4.doFetch(`${Client4.getBaseRoute()}/trial-license`, {
             method: 'POST', body: JSON.stringify({users, terms_accepted: true, receive_emails_accepted: true}),

--- a/webapp/src/components/backstage/upgrade_modal.tsx
+++ b/webapp/src/components/backstage/upgrade_modal.tsx
@@ -39,7 +39,7 @@ const UpgradeModal: FC<Props> = (props: Props) => {
         setActionState(ModalActionState.Loading);
 
         const requestedUsers = Math.max(serverTotalUsers, 30);
-        const response = await requestTrialLicense(requestedUsers);
+        const response = await requestTrialLicense(requestedUsers, props.messageType);
         if (response.error) {
             setActionState(ModalActionState.Error);
         } else {

--- a/webapp/src/components/rhs/rhs_timeline_placeholder.tsx
+++ b/webapp/src/components/rhs/rhs_timeline_placeholder.tsx
@@ -61,7 +61,7 @@ const TimelineUpgradePlaceholder : FC = () => {
         setActionState(ActionState.Loading);
 
         const requestedUsers = Math.max(serverTotalUsers, 30);
-        const response = await requestTrialLicense(requestedUsers);
+        const response = await requestTrialLicense(requestedUsers, AdminNotificationType.VIEW_TIMELINE);
         if (response.error) {
             setActionState(ActionState.Error);
         } else {

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -18,9 +18,9 @@ export const BACKSTAGE_LIST_PER_PAGE = 15;
 export const PROFILE_CHUNK_SIZE = 200;
 
 export enum AdminNotificationType {
-    PLAYBOOK = 'playbook',
-    VIEW_TIMELINE = 'view_timeline',
-    MESSAGE_TO_TIMELINE = 'message_to_timeline',
-    PLAYBOOK_GRANULAR_ACCESS = 'playbook_granular_access',
-    PLAYBOOK_CREATION_RESTRICTION = 'playbook_creation_restriction',
+    PLAYBOOK = 'start_trial_to_create_playbook',
+    VIEW_TIMELINE = 'start_trial_to_view_timeline',
+    MESSAGE_TO_TIMELINE = 'start_trial_to_add_message_to_timeline',
+    PLAYBOOK_GRANULAR_ACCESS = 'start_trial_to_restrict_playbook_access',
+    PLAYBOOK_CREATION_RESTRICTION = 'start_trial_to_restrict_playbook_creation',
 }


### PR DESCRIPTION
#### Summary
Add telemetry for the pricing differentiation features: when the admins click on Start Trial or the end users click on Notify System Admin.

While I was here, I moved the `/telemetry` API endpoints that were inside the Incident router to a generic telemetry subrouter.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35889

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [X] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [X] Unit tests updated