### PR TITLE
MM-35045 Template retrospective report

### DIFF
--- a/server/api/incidents.go
+++ b/server/api/incidents.go
@@ -404,6 +404,7 @@ func (h *IncidentHandler) createIncident(newIncident incident.Incident, userID s
 		}
 
 		newIncident.RetrospectiveReminderIntervalSeconds = pb.RetrospectiveReminderIntervalSeconds
+		newIncident.Retrospective = pb.RetrospectiveTemplate
 
 		thePlaybook = &pb
 	}

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -37,6 +37,7 @@ type Playbook struct {
 	MessageOnJoin                        string      `json:"message_on_join"`
 	MessageOnJoinEnabled                 bool        `json:"message_on_join_enabled"`
 	RetrospectiveReminderIntervalSeconds int64       `json:"retrospective_reminder_interval_seconds"`
+	RetrospectiveTemplate                string      `json:"retrospective_template"`
 }
 
 func (p Playbook) Clone() Playbook {

--- a/server/sqlstore/migrations.go
+++ b/server/sqlstore/migrations.go
@@ -772,4 +772,26 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		fromVersion: semver.MustParse("0.18.0"),
+		toVersion:   semver.MustParse("0.19.0"),
+		migrationFunc: func(e sqlx.Ext, sqlStore *SQLStore) error {
+			if e.DriverName() == model.DATABASE_DRIVER_MYSQL {
+				if err := addColumnToMySQLTable(e, "IR_Playbook", "RetrospectiveTemplate", "TEXT"); err != nil {
+					return errors.Wrapf(err, "failed adding column RetrospectiveReminderIntervalSeconds to table IR_Playbook")
+				}
+
+			} else {
+				if err := addColumnToPGTable(e, "IR_Playbook", "RetrospectiveTemplate", "TEXT"); err != nil {
+					return errors.Wrapf(err, "failed adding column RetrospectiveReminderIntervalSeconds to table IR_Playbook")
+				}
+			}
+
+			if _, err := e.Exec("UPDATE IR_Playbook SET RetrospectiveTemplate = '' WHERE RetrospectiveTemplate IS NULL"); err != nil {
+				return errors.Wrapf(err, "failed setting default value in column RetrospectiveTemplate of table IR_Playbook")
+			}
+
+			return nil
+		},
+	},
 }

--- a/server/sqlstore/playbook.go
+++ b/server/sqlstore/playbook.go
@@ -50,7 +50,8 @@ func NewPlaybookStore(pluginAPI PluginAPIClient, log bot.Logger, sqlStore *SQLSt
 			"AnnouncementChannelID", "AnnouncementChannelEnabled",
 			"WebhookOnCreationURL", "WebhookOnCreationEnabled",
 			"MessageOnJoin", "MessageOnJoinEnabled",
-			"RetrospectiveReminderIntervalSeconds").
+			"RetrospectiveReminderIntervalSeconds",
+			"RetrospectiveTemplate").
 		From("IR_Playbook")
 
 	memberIDsSelect := sqlStore.builder.
@@ -114,6 +115,7 @@ func (p *playbookStore) Create(pbook playbook.Playbook) (id string, err error) {
 			"MessageOnJoin":                        rawPlaybook.MessageOnJoin,
 			"MessageOnJoinEnabled":                 rawPlaybook.MessageOnJoinEnabled,
 			"RetrospectiveReminderIntervalSeconds": rawPlaybook.RetrospectiveReminderIntervalSeconds,
+			"RetrospectiveTemplate":                rawPlaybook.RetrospectiveTemplate,
 		}))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to store new playbook")
@@ -330,6 +332,7 @@ func (p *playbookStore) Update(updated playbook.Playbook) (err error) {
 			"MessageOnJoin":                        rawPlaybook.MessageOnJoin,
 			"MessageOnJoinEnabled":                 rawPlaybook.MessageOnJoinEnabled,
 			"RetrospectiveReminderIntervalSeconds": rawPlaybook.RetrospectiveReminderIntervalSeconds,
+			"RetrospectiveTemplate":                rawPlaybook.RetrospectiveTemplate,
 		}).
 		Where(sq.Eq{"ID": rawPlaybook.ID}))
 

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -539,6 +539,7 @@ const PlaybookEdit = (props: Props) => {
                                     />
                                 </SidebarBlock>
                                 {experimentalFeaturesEnabled &&
+                                <>
                                     <SidebarBlock>
                                         <BackstageSubheader>
                                             {'Retrospective Reminder Interval'}
@@ -560,6 +561,26 @@ const PlaybookEdit = (props: Props) => {
                                             isClearable={false}
                                         />
                                     </SidebarBlock>
+                                    <SidebarBlock>
+                                        <BackstageSubheader>
+                                            {'Retrospective Template'}
+                                            <BackstageSubheaderDescription>
+                                                {'Default text for the retrospective.'}
+                                            </BackstageSubheaderDescription>
+                                        </BackstageSubheader>
+                                        <StyledTextarea
+                                            placeholder={'Enter retrospective template'}
+                                            value={playbook.retrospective_template}
+                                            onChange={(e) => {
+                                                setPlaybook({
+                                                    ...playbook,
+                                                    retrospective_template: e.target.value,
+                                                });
+                                                setChangesMade(true);
+                                            }}
+                                        />
+                                    </SidebarBlock>
+                                </>
                                 }
                             </TabContainer>
                             <TabContainer>

--- a/webapp/src/types/playbook.ts
+++ b/webapp/src/types/playbook.ts
@@ -24,6 +24,7 @@ export interface Playbook {
     message_on_join: string;
     message_on_join_enabled: boolean;
     retrospective_reminder_interval_seconds: number;
+    retrospective_template: string;
 }
 
 export interface PlaybookNoChecklist {
@@ -100,6 +101,7 @@ export function emptyPlaybook(): Playbook {
         message_on_join: defaultMessageOnJoin,
         message_on_join_enabled: false,
         retrospective_reminder_interval_seconds: 0,
+        retrospective_template: defaultRetrospectiveTemplate,
     };
 }
 
@@ -180,3 +182,24 @@ export const defaultMessageOnJoin = 'Welcome. This channel was automatically cre
     '\n' +
     '[Mattermost Incident Collaboration channel](https://community.mattermost.com/core/channels/ee-incident-response)\n' +
     '[Incident Collaboration documentation](https://docs.mattermost.com/administration/devops-command-center.html)';
+
+export const defaultRetrospectiveTemplate = `### Summary
+This should contain 2-3 sentences that gives a reader an overview of what happened, what was the cause, and what was done. The briefer the better as this is what future teams will look at first for reference.
+
+### What was the impact?
+This section describes the impact of this playbook run as experienced by internal and external customers as well as stakeholders.
+
+### What were the contributing factors?
+This playbook may be a reactive protocol to a situation that is otherwise undesirable. If that's the case, this section explains the reasons that caused the situation in the first place. There may be multiple root causes - this helps stakeholders understand why.
+
+### What was done?
+This section tells the story of how the team collaborated throughout the event to achieve the outcome. This will help future teams learn from this experience on what they could try.
+
+### What did we learn?
+This section should include perspective from everyone that was involved to celebrate the victories and identify areas for improvement. For example: What went well? What didn't go well? What should be done differently next time?
+
+### Follow-up tasks
+This section lists the action items to turn learnings into changes that help the team become more proficient with iterations. It could include tweaking the playbook, publishing the retrospective, or other improvements. The best follow-ups will have clear owner assigned as well as due date.
+
+### Timeline Highlights
+This section is a curated log that details the most important moments. It can contain key communications, screen shots, or other artifacts. Use the built-in timeline feature to help you retrace and replay the sequence of events.`;


### PR DESCRIPTION
#### Summary
Adds the ability to template the retrospective report.

Built on top of https://github.com/mattermost/mattermost-plugin-incident-collaboration/pull/566

#### Where we are
- **Placeholder Elements**
- **Basic saving of retrospective** 
- **Ability to publish retrospective** 
- **Reminder to fill out retrospective**
- **Configurable persistent reminders** 
- **Templating retrospective report** <-- We are here
- _NEW:_ Replace reminder message with custom message for interactivity.
- _NEW:_ Add ability to disable retrospectives at playbook level.
- Polish

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35045

#### Checklist
- ~~[ ] Telemetry updated~~
- [x] Gated by experimental feature flag
- [x] Unit tests updated
