### PR TITLE
Fix channel selector selector

### DIFF
--- a/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
+++ b/tests-e2e/cypress/integration/backstage/playbook_details_spec.js
@@ -816,7 +816,7 @@ describe('backstage playbook details', () => {
 
                     // * Verify that the channel selector is disabled
                     cy.get('#announcement-channel').within(() => {
-                        cy.getStyledComponent('StyledAsyncSelect').should('have.class', 'channel-selector--is-disabled');
+                        cy.getStyledComponent('StyledSelect').should('have.class', 'channel-selector--is-disabled');
                     });
                 });
 

--- a/webapp/src/components/backstage/channel_selector.tsx
+++ b/webapp/src/components/backstage/channel_selector.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import {OptionsType, SelectComponentsConfig, components as defaultComponents} from 'react-select';
+import {SelectComponentsConfig, components as defaultComponents} from 'react-select';
 import {useSelector} from 'react-redux';
 import {getMyChannels, getChannel} from 'mattermost-redux/selectors/entities/channels';
+import General from 'mattermost-redux/constants/general';
 
 import {Channel} from 'mattermost-redux/types/channels';
 import {GlobalState} from 'mattermost-redux/types/store';
 
-import {StyledAsyncSelect} from './styles';
+import {StyledSelect} from './styles';
 
 export interface Props {
     id?: string;
@@ -20,8 +21,12 @@ export interface Props {
     placeholder?: string;
 }
 
+const getMyPublicAndPrivateChannels = (state: GlobalState) => getMyChannels(state).filter((channel) =>
+    channel.type !== General.DM_CHANNEL && channel.type !== General.GM_CHANNEL,
+);
+
 const ChannelSelector = (props: Props & { className?: string }) => {
-    const selectableChannels = useSelector(getMyChannels);
+    const selectableChannels = useSelector(getMyPublicAndPrivateChannels);
 
     type GetChannelType = (channelID: string) => Channel
     const getChannelFromID = useSelector<GlobalState, GetChannelType>((state) => (channelID) => getChannel(state, channelID) || {display_name: 'Unknown Channel', id: channelID});
@@ -42,17 +47,16 @@ const ChannelSelector = (props: Props & { className?: string }) => {
         );
     };
 
-    const channelsLoader = (term: string, callback: (options: OptionsType<Channel>) => void) => {
+    const filterOption = (option: {label: string, value: string, data: Channel}, term: string): boolean => {
+        const channel = option.data as Channel;
+
         if (term.trim().length === 0) {
-            callback(selectableChannels);
-        } else {
-            // Implement rudimentary channel name searches.
-            callback(selectableChannels.filter((channel) => (
-                channel.name.toLowerCase().includes(term.toLowerCase()) ||
-                channel.display_name.toLowerCase().includes(term.toLowerCase()) ||
-                channel.id.toLowerCase() === term.toLowerCase()
-            )));
+            return true;
         }
+
+        return channel.name.toLowerCase().includes(term.toLowerCase()) ||
+               channel.display_name.toLowerCase().includes(term.toLowerCase()) ||
+               channel.id.toLowerCase() === term.toLowerCase();
     };
 
     const value = props.channelId && getChannelFromID(props.channelId);
@@ -60,14 +64,13 @@ const ChannelSelector = (props: Props & { className?: string }) => {
     const components = props.selectComponents || defaultComponents;
 
     return (
-        <StyledAsyncSelect
+        <StyledSelect
             className={props.className}
             id={props.id}
             isMulti={false}
             controlShouldRenderValue={props.shouldRenderValue}
-            cacheOptions={false}
-            defaultOptions={true}
-            loadOptions={channelsLoader}
+            options={selectableChannels}
+            filterOption={filterOption}
             onChange={onChange}
             getOptionValue={getOptionValue}
             formatOptionLabel={formatOptionLabel}


### PR DESCRIPTION
#### Summary
The channel selector did not respond to Redux changes to the available channels. While this is rarely a problem in normal usage, when the set of channels aren't likely to change in the backstage, it did cause issues during e2e tests when the selector raced with the messaging application's initial load of available channels.

Switch from `AsyncSelect` to just a controlled `Select` component that directly renders from the selected channels. While we're in here, exclude DMs and GMs from the list of selectable channels.

#### Ticket Link
None

#### Checklist
[ ] ~~Telemetry updated~~
[ ] ~~Gated by experimental feature flag~~
[ ] ~~Unit tests updated~~
