### PR TITLE
MM-36042: Fix admin notification on playbook restriction

### DIFF
--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -124,7 +124,7 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 		message = fmt.Sprintf("@%s requested access to configure who can access specific playbooks in Incident Collaboration.", author.Username)
 		title = "Control who can access specific playbooks in Incident Collaboration with Mattermost Enterprise Edition E20"
 		text = "Playbooks are workflows that provide guidance through an incident. In Enterprise Edition E20 you can set playbook permissions for specific users or set a global permission to control which team members can create playbooks.\n" + footer
-	case "strat_trial_to_restrict_playbook_creation":
+	case "start_trial_to_restrict_playbook_creation":
 		message = fmt.Sprintf("@%s requested access to configure who can create playbooks in Incident Collaboration.", author.Username)
 		title = "Control who can create playbooks in Incident Collaboration with Mattermost Enterprise Edition E20"
 		text = "Playbooks are workflows that provide guidance through an incident. In Enterprise Edition E20 you can set playbook permissions for specific users or set a global permission to control which team members can create playbooks.\n" + footer


### PR DESCRIPTION
#### Summary
Found this bug while working on something else. This should be cherry-picked to v1.11.1.

The problem was that the string had a typo, so the case never ran, and the message never got populated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36042

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
