### PR TITLE
MM-36263 Fix to show as much of retrospective as possible.

### DIFF
--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -33,6 +33,8 @@ import SettingsView from './settings';
 const BackstageContainer = styled.div`
     background: var(--center-channel-bg);
     height: 100%;
+    display: flex;
+    flex-direction: column;
     overflow-y: auto;
 `;
 
@@ -102,7 +104,7 @@ const BackstageTitlebarItem = styled(NavLink)`
 
 const BackstageBody = styled.div`
     z-index: 1;
-    margin: 0 auto;
+    flex-grow: 1;
 `;
 
 const Backstage = () => {

--- a/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/incident_backstage.tsx
@@ -29,6 +29,7 @@ const OuterContainer = styled.div`
     background: var(center-channel-bg);
     display: flex;
     flex-direction: column;
+    height: 100%;
 `;
 
 const TopContainer = styled.div`
@@ -63,8 +64,10 @@ const BottomContainer = styled.div`
 
 const InnerContainer = styled.div`
     padding: 20px;
+    padding-top: 40px;
     max-width: 1120px;
     margin: 0 auto;
+    height: 100%;
     font-family: 'Open Sans', sans-serif;
     font-style: normal;
     font-weight: 600;

--- a/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
+++ b/webapp/src/components/backstage/incidents/incident_backstage/retrospective/report.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 
 import {StyledTextarea} from 'src/components/backstage/styles';
 import {
-    TabPageContainer,
     Title,
     SecondaryButton,
 } from 'src/components/backstage/incidents/shared';
@@ -23,8 +22,8 @@ const Header = styled.div`
 const ReportTextarea = styled(StyledTextarea)`
     margin: 8px 0 0 0;
     min-height: 200px;
-    resize: vertical;
     font-size: 12px;
+    flex-grow: 1;
 `;
 
 const CustomPrimaryButton = styled(PrimaryButton)`
@@ -42,10 +41,21 @@ const HeaderButtonsRight = styled.div`
 `;
 
 const PostTextContainer = styled.div`
+    background: var(--center-channel-bg);
     margin: 8px 0 0 0;
     padding: 10px 25px 0 16px;
     border: 1px solid var(--center-channel-color-08);
     border-radius: 8px;
+    flex-grow: 1;
+`;
+
+const ReportContainer = styled.div`
+    font-size: 12px;
+    font-weight: normal;
+    margin-bottom: 20px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
 `;
 
 interface ReportProps {
@@ -81,7 +91,7 @@ const Report = (props: ReportProps) => {
     }
 
     return (
-        <TabPageContainer>
+        <ReportContainer>
             <Header>
                 <Title>{'Report'}</Title>
                 <HeaderButtonsRight>
@@ -110,7 +120,7 @@ const Report = (props: ReportProps) => {
                     <PostText text={report}/>
                 </PostTextContainer>
             }
-        </TabPageContainer>
+        </ReportContainer>
     );
 };
 

--- a/webapp/src/components/backstage/incidents/shared.tsx
+++ b/webapp/src/components/backstage/incidents/shared.tsx
@@ -8,6 +8,7 @@ import StatusBadge from 'src/components/backstage/incidents/status_badge';
 
 export const Container = styled.div`
     display: flex;
+    height: 100%;
 `;
 
 export const Left = styled.div`
@@ -22,7 +23,7 @@ export const Right = styled.div`
 export const TabPageContainer = styled.div`
     font-size: 12px;
     font-weight: normal;
-    margin-top: 20px;
+    margin-bottom: 20px;
 `;
 
 export const Title = styled.div`


### PR DESCRIPTION
#### Summary
Modifies the styling on the retrospective report page to always show as much of the retrospective as possible. 

![image](https://user-images.githubusercontent.com/3191642/121408068-d1b8a500-c914-11eb-9b58-b66f07f925c9.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36263

#### Checklist
~~- [ ] Telemetry updated~~
- [x] Gated by experimental feature flag
~~- [ ] Unit tests updated~~
