### PR TITLE
MM-36359 - Fix backstage stats not working on MySql

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -111,6 +111,7 @@ func (p *Plugin) OnActivate() error {
 	p.config.RegisterConfigChangeListener(toggleTelemetry)
 
 	apiClient := sqlstore.NewClient(pluginAPIClient)
+	p.bot = bot.New(pluginAPIClient, p.config.GetConfiguration().BotUserID, p.config, telemetryClient)
 	sqlStore, err := sqlstore.New(apiClient, p.bot)
 	if err != nil {
 		return errors.Wrapf(err, "failed creating the SQL store")
@@ -133,7 +134,6 @@ func (p *Plugin) OnActivate() error {
 	statsStore := sqlstore.NewStatsStore(apiClient, p.bot, sqlStore)
 
 	p.handler = api.NewHandler(pluginAPIClient, p.config, p.bot)
-	p.bot = bot.New(pluginAPIClient, p.config.GetConfiguration().BotUserID, p.config, telemetryClient)
 
 	scheduler := cluster.GetJobOnceScheduler(p.API)
 


### PR DESCRIPTION
#### Summary
- This was weird. MySql's sum returns an int (but not always). Then, squirrel interpreted it as a `[]uint8` (!?). This fixcasts it to something we expect.
- Changing the type check to fail and give us some info, in case this happens again
- Remember that nil dereference we got from community a few days ago? Turns out it was because we were using an uninitialized bot to report errors. Fixed that.
- I think I should write tests for the time-related stats, but these pages are changing so fast I don't think it's worth the time -- propose we wait till the features are a little more stable.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-36359
