### PR TITLE
Removed unused member_only

### DIFF
--- a/client/playbook.go
+++ b/client/playbook.go
@@ -70,9 +70,6 @@ type PlaybookCreateOptions struct {
 // PlaybookListOptions specifies the optional parameters to the
 // PlaybooksService.List method.
 type PlaybookListOptions struct {
-	// MemberOnly filters playbooks to those for which the current user is a member.
-	MemberOnly bool `url:"member_only,omitempty"`
-
 	Sort      Sort          `url:"sort,omitempty"`
 	Direction SortDirection `url:"direction,omitempty"`
 }

--- a/server/api/api.yaml
+++ b/server/api/api.yaml
@@ -1334,14 +1334,6 @@ paths:
             enum:
               - desc
               - asc
-        - name: member_only
-          in: query
-          description: Limit to playbooks of which the current user is a member. No effect unless the requesting user is a system administrator.
-          required: false
-          example: true
-          schema:
-            type: boolean
-            default: false
       x-codeSamples:
         - lang: curl
           source: |

--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -281,7 +281,6 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 		h.HandleErrorWithCode(w, http.StatusBadRequest, fmt.Sprintf("failed to get playbooks: %s", err.Error()), nil)
 		return
 	}
-	memberOnly, _ := strconv.ParseBool(params.Get("member_only"))
 
 	if teamID == "" {
 		h.HandleErrorWithCode(w, http.StatusBadRequest, "Provide a team ID", nil)
@@ -314,7 +313,6 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 		UserID:          userID,
 		TeamID:          teamID,
 		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
-		MemberOnly:      memberOnly,
 	}
 
 	playbookResults, err := h.playbookService.GetPlaybooksForTeam(requesterInfo, teamID, opts)
@@ -340,7 +338,6 @@ func (h *PlaybookHandler) getPlaybooksAutoComplete(w http.ResponseWriter, r *htt
 		UserID:          userID,
 		TeamID:          teamID,
 		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
-		MemberOnly:      true,
 	}
 
 	playbooksResult, err := h.playbookService.GetPlaybooksForTeam(requesterInfo, teamID, playbook.Options{})

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -963,7 +963,6 @@ func TestPlaybooks(t *testing.T) {
 					UserID:          "testuserid",
 					TeamID:          "testteamid",
 					UserIDtoIsAdmin: map[string]bool{"testuserid": true},
-					MemberOnly:      true,
 				},
 				"testteamid",
 				gomock.Any(),
@@ -975,9 +974,7 @@ func TestPlaybooks(t *testing.T) {
 		pluginAPI.On("HasPermissionTo", "testuserid", model.PERMISSION_MANAGE_SYSTEM).Return(true)
 		pluginAPI.On("GetUser", "testuserid").Return(&model.User{}, nil)
 
-		actualList, err := c.Playbooks.List(context.TODO(), "testteamid", 0, 100, icClient.PlaybookListOptions{
-			MemberOnly: true,
-		})
+		actualList, err := c.Playbooks.List(context.TODO(), "testteamid", 0, 100, icClient.PlaybookListOptions{})
 		require.NoError(t, err)
 
 		expectedList := &icClient.GetPlaybooksResults{

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -214,7 +214,6 @@ func (r *Runner) actionStart(args []string) {
 		UserID:          r.args.UserId,
 		TeamID:          r.args.TeamId,
 		UserIDtoIsAdmin: map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
-		MemberOnly:      true,
 	}
 
 	playbooksResults, err := r.playbookService.GetPlaybooksForTeam(requesterInfo, r.args.TeamId,
@@ -1280,7 +1279,6 @@ func (r *Runner) generateTestData(numActiveIncidents, numEndedIncidents int, beg
 		UserID:          r.args.UserId,
 		TeamID:          r.args.TeamId,
 		UserIDtoIsAdmin: map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
-		MemberOnly:      true,
 	}
 
 	playbooksResult, err := r.playbookService.GetPlaybooksForTeam(requesterInfo, r.args.TeamId, playbook.Options{})

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -143,9 +143,6 @@ type RequesterInfo struct {
 	UserID          string
 	TeamID          string
 	UserIDtoIsAdmin map[string]bool
-
-	// MemberOnly filters playbooks to those for which UserId is a member
-	MemberOnly bool
 }
 
 // Service is the playbook service for managing playbooks

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -632,7 +632,6 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
 				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
-				MemberOnly:      true,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -827,25 +826,6 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 				PageCount:  1,
 				HasMore:    false,
 				Items:      []playbook.Playbook{pb07, pb08},
-			},
-			expectedErr: nil,
-		},
-		{
-			name:   "team3 from Admin, memberOnly",
-			teamID: team3id,
-			requesterInfo: playbook.RequesterInfo{
-				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
-				MemberOnly:      true,
-			},
-			options: playbook.Options{
-				Sort: playbook.SortByTitle,
-			},
-			expected: playbook.GetPlaybooksResults{
-				TotalCount: 1,
-				PageCount:  1,
-				HasMore:    false,
-				Items:      []playbook.Playbook{pb08},
 			},
 			expectedErr: nil,
 		},*/

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -145,7 +145,6 @@ const clientHasPlaybooks = async (teamID: string): Promise<boolean> => {
     const result = await clientFetchPlaybooks(teamID, {
         page: 0,
         per_page: 1,
-        member_only: true,
     }) as FetchPlaybooksNoChecklistReturn;
 
     return result.items?.length > 0;

--- a/webapp/src/types/incident.ts
+++ b/webapp/src/types/incident.ts
@@ -158,5 +158,4 @@ export interface FetchPlaybooksParams {
     per_page?: number;
     sort?: string;
     direction?: string;
-    member_only?: boolean;
 }


### PR DESCRIPTION
#### Summary
The `member_only` parameter on the playbooks endpoint is unused. Remove it to simplify subsequent changes.

#### Ticket Link
None.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
