### PR TITLE
s/UserIDtoIsAdmin/IsAdmin

### DIFF
--- a/server/api/playbooks.go
+++ b/server/api/playbooks.go
@@ -310,9 +310,9 @@ func (h *PlaybookHandler) getPlaybooks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requesterInfo := playbook.RequesterInfo{
-		UserID:          userID,
-		TeamID:          teamID,
-		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
+		UserID:  userID,
+		TeamID:  teamID,
+		IsAdmin: permissions.IsAdmin(userID, h.pluginAPI),
 	}
 
 	playbookResults, err := h.playbookService.GetPlaybooksForTeam(requesterInfo, teamID, opts)
@@ -335,9 +335,9 @@ func (h *PlaybookHandler) getPlaybooksAutoComplete(w http.ResponseWriter, r *htt
 	}
 
 	requesterInfo := playbook.RequesterInfo{
-		UserID:          userID,
-		TeamID:          teamID,
-		UserIDtoIsAdmin: map[string]bool{userID: permissions.IsAdmin(userID, h.pluginAPI)},
+		UserID:  userID,
+		TeamID:  teamID,
+		IsAdmin: permissions.IsAdmin(userID, h.pluginAPI),
 	}
 
 	playbooksResult, err := h.playbookService.GetPlaybooksForTeam(requesterInfo, teamID, playbook.Options{})

--- a/server/api/playbooks_test.go
+++ b/server/api/playbooks_test.go
@@ -878,9 +878,9 @@ func TestPlaybooks(t *testing.T) {
 		playbookService.EXPECT().
 			GetPlaybooksForTeam(
 				playbook.RequesterInfo{
-					UserID:          "testuserid",
-					TeamID:          "testteamid",
-					UserIDtoIsAdmin: map[string]bool{"testuserid": true},
+					UserID:  "testuserid",
+					TeamID:  "testteamid",
+					IsAdmin: true,
 				},
 				"testteamid",
 				gomock.Any(),
@@ -923,9 +923,9 @@ func TestPlaybooks(t *testing.T) {
 		playbookService.EXPECT().
 			GetPlaybooksForTeam(
 				playbook.RequesterInfo{
-					UserID:          "testuserid",
-					TeamID:          "testteamid",
-					UserIDtoIsAdmin: map[string]bool{"testuserid": true},
+					UserID:  "testuserid",
+					TeamID:  "testteamid",
+					IsAdmin: true,
 				},
 				"testteamid",
 				gomock.Any(),
@@ -960,9 +960,9 @@ func TestPlaybooks(t *testing.T) {
 		playbookService.EXPECT().
 			GetPlaybooksForTeam(
 				playbook.RequesterInfo{
-					UserID:          "testuserid",
-					TeamID:          "testteamid",
-					UserIDtoIsAdmin: map[string]bool{"testuserid": true},
+					UserID:  "testuserid",
+					TeamID:  "testteamid",
+					IsAdmin: true,
 				},
 				"testteamid",
 				gomock.Any(),
@@ -1466,9 +1466,9 @@ func TestPlaybooks(t *testing.T) {
 		playbookService.EXPECT().
 			GetPlaybooksForTeam(
 				playbook.RequesterInfo{
-					UserID:          "testuserid",
-					TeamID:          "testteamid",
-					UserIDtoIsAdmin: map[string]bool{"testuserid": false},
+					UserID:  "testuserid",
+					TeamID:  "testteamid",
+					IsAdmin: false,
 				},
 				"testteamid",
 				gomock.Any(),
@@ -1726,9 +1726,9 @@ func TestSortingPlaybooks(t *testing.T) {
 			playbookService.EXPECT().
 				GetPlaybooksForTeam(
 					playbook.RequesterInfo{
-						UserID:          "testuserid",
-						TeamID:          "testteamid",
-						UserIDtoIsAdmin: map[string]bool{"testuserid": true},
+						UserID:  "testuserid",
+						TeamID:  "testteamid",
+						IsAdmin: true,
 					},
 					"testteamid",
 					gomock.Any(),
@@ -1961,9 +1961,9 @@ func TestPagingPlaybooks(t *testing.T) {
 			playbookService.EXPECT().
 				GetPlaybooksForTeam(
 					playbook.RequesterInfo{
-						UserID:          "testuserid",
-						TeamID:          "testteamid",
-						UserIDtoIsAdmin: map[string]bool{"testuserid": true},
+						UserID:  "testuserid",
+						TeamID:  "testteamid",
+						IsAdmin: true,
 					},
 					"testteamid",
 					gomock.Any(),

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -211,9 +211,9 @@ func (r *Runner) actionStart(args []string) {
 	}
 
 	requesterInfo := playbook.RequesterInfo{
-		UserID:          r.args.UserId,
-		TeamID:          r.args.TeamId,
-		UserIDtoIsAdmin: map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
+		UserID:  r.args.UserId,
+		TeamID:  r.args.TeamId,
+		IsAdmin: permissions.IsAdmin(r.args.UserId, r.pluginAPI),
 	}
 
 	playbooksResults, err := r.playbookService.GetPlaybooksForTeam(requesterInfo, r.args.TeamId,
@@ -1276,9 +1276,9 @@ func (r *Runner) generateTestData(numActiveIncidents, numEndedIncidents int, beg
 	}
 
 	requesterInfo := playbook.RequesterInfo{
-		UserID:          r.args.UserId,
-		TeamID:          r.args.TeamId,
-		UserIDtoIsAdmin: map[string]bool{r.args.UserId: permissions.IsAdmin(r.args.UserId, r.pluginAPI)},
+		UserID:  r.args.UserId,
+		TeamID:  r.args.TeamId,
+		IsAdmin: permissions.IsAdmin(r.args.UserId, r.pluginAPI),
 	}
 
 	playbooksResult, err := r.playbookService.GetPlaybooksForTeam(requesterInfo, r.args.TeamId, playbook.Options{})

--- a/server/playbook/playbook.go
+++ b/server/playbook/playbook.go
@@ -140,9 +140,9 @@ func (r GetPlaybooksResults) MarshalJSON() ([]byte, error) {
 
 // RequesterInfo holds the userID and permissions for the user making the request
 type RequesterInfo struct {
-	UserID          string
-	TeamID          string
-	UserIDtoIsAdmin map[string]bool
+	UserID  string
+	TeamID  string
+	IsAdmin bool
 }
 
 // Service is the playbook service for managing playbooks

--- a/server/sqlstore/playbook_test.go
+++ b/server/sqlstore/playbook_test.go
@@ -594,8 +594,8 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			name:   "team1 from Admin, no special access",
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
-				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				UserID:  lucia.ID,
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -613,7 +613,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -631,7 +631,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,
@@ -649,7 +649,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortBySteps,
@@ -668,7 +668,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByTitle,
@@ -687,7 +687,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortBySteps,
@@ -705,7 +705,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortBySteps,
@@ -724,7 +724,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortBySteps,
@@ -743,7 +743,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByStages,
@@ -761,7 +761,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team1id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort:      playbook.SortByStages,
@@ -816,7 +816,7 @@ func TestGetPlaybooksForTeam(t *testing.T) {
 			teamID: team3id,
 			requesterInfo: playbook.RequesterInfo{
 				UserID:          lucia.ID,
-				UserIDtoIsAdmin: map[string]bool{lucia.ID: true},
+				IsAdmin: true,
 			},
 			options: playbook.Options{
 				Sort: playbook.SortByTitle,


### PR DESCRIPTION
#### Summary
Simplify the `playbook.RequestInfo` struct to just use an `IsAdmin` bit instead of the old `UserIDtoIsAdmin` map which could track multiple users. This is part of the clean up necessary to collapse the `playbook`, `incident` and `permissions` packages into an `app` package, and ultimately streamline the renaming of `incident` to `run` (or `playbookRun`).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35597

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
