### PR TITLE
MM-36474: Skip useOpenCloudModal creation if not in cloud

### DIFF
--- a/webapp/src/hooks.ts
+++ b/webapp/src/hooks.ts
@@ -24,7 +24,7 @@ import {Incident, StatusPost} from 'src/types/incident';
 import {clientFetchPlaybooksCount} from 'src/client';
 import {receivedTeamNumPlaybooks} from 'src/actions';
 
-import {isE10LicensedOrDevelopment, isE20LicensedOrDevelopment} from './license';
+import {isCloud, isE10LicensedOrDevelopment, isE20LicensedOrDevelopment} from './license';
 import {currentTeamNumPlaybooks, globalSettings} from './selectors';
 
 export function useCurrentTeamPermission(options: PermissionsOptions): boolean {
@@ -288,6 +288,11 @@ export function useEnsureProfiles(userIds: string[]) {
 
 export function useOpenCloudModal() {
     const dispatch = useDispatch();
+    const isServerCloud = useSelector(isCloud);
+
+    if (!isServerCloud) {
+        return () => { /*do nothing*/ };
+    }
 
     // @ts-ignore
     if (!window.WebappUtils?.modals?.openModal || !window.WebappUtils?.modals?.ModalIdentifiers?.CLOUD_PURCHASE || !window.Components?.PurchaseModal) {


### PR DESCRIPTION
#### Summary
Skip trying to build the openCloudModal function when not in Cloud, returning a void function. This gets rid of the error emitted on self-managed installations that have an older webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36474

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
