### PR TITLE
Bump mattermost-plugin-api version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/jmoiron/sqlx v1.3.1
 	github.com/lib/pq v1.10.0
-	github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210514101030-33637915555a
+	github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210617150024-a576c5d40298
 	github.com/mattermost/mattermost-plugin-incident-collaboration/client v0.3.1
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210514083559-0bf7aed02e2c
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -598,6 +598,8 @@ github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
 github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210514101030-33637915555a h1:WboYA4ULZrNIBZaCPnfsTHJ8Lz+5cimh9d3R/Jt7CEU=
 github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210514101030-33637915555a/go.mod h1:3JGRR6D/un0HBb3HBy9npMXmDUluvWFMmAE5za5o8tw=
+github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210617150024-a576c5d40298 h1:AJ21NyXIPGj2OrPXdfhQpLFl0+AVbPx64FjbMFo5okA=
+github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210617150024-a576c5d40298/go.mod h1:3JGRR6D/un0HBb3HBy9npMXmDUluvWFMmAE5za5o8tw=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210412170128-2de65cfb1160/go.mod h1:xn2/aF7VrTae7Ad6mVmHPA2T3Si1cl3K67xgp9O/Zag=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210514083559-0bf7aed02e2c h1:MdnrC+oQ7S1RehNGqYavOZyZd2ig1Ml1ggBQOT1rFK4=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210514083559-0bf7aed02e2c/go.mod h1:6CqGEG0Vnhrl23h8LB+lcOIT8KIUhzbJ7qhXlV7Ek9U=

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,6 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210514101030-33637915555a h1:WboYA4ULZrNIBZaCPnfsTHJ8Lz+5cimh9d3R/Jt7CEU=
-github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210514101030-33637915555a/go.mod h1:3JGRR6D/un0HBb3HBy9npMXmDUluvWFMmAE5za5o8tw=
 github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210617150024-a576c5d40298 h1:AJ21NyXIPGj2OrPXdfhQpLFl0+AVbPx64FjbMFo5okA=
 github.com/mattermost/mattermost-plugin-api v0.0.16-0.20210617150024-a576c5d40298/go.mod h1:3JGRR6D/un0HBb3HBy9npMXmDUluvWFMmAE5za5o8tw=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210412170128-2de65cfb1160/go.mod h1:xn2/aF7VrTae7Ad6mVmHPA2T3Si1cl3K67xgp9O/Zag=


### PR DESCRIPTION
#### Summary
This is just to get the latest changes for license checks: https://github.com/mattermost/mattermost-plugin-api/pull/91

#### Ticket Link
--

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
