### PR TITLE
Require mattermost-server 5.37

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-incident-collaboration/",
     "support_url": "https://github.com/mattermost/mattermost-plugin-incident-collaboration/issues",
     "icon_path": "assets/incident_plugin_icon.svg",
-    "min_server_version": "5.28.0",
+    "min_server_version": "5.37.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
This is a follow-up to @agnivade's changes to use the plugin-api for managing the DB connection pool instead of just hard-coding two. Once deployed, the plugin will only be live on `-daily` until `community` is upgraded on July 16th. Marketplace users will not be prompted to upgrade until they are running at least v5.37.

#### Ticket Link
None.

#### Checklist
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- ~~[ ] Unit tests updated~~
