### PR TITLE
MM-36689: Match export channel UX to all other restricted features

### DIFF
--- a/server/api/telemetry.go
+++ b/server/api/telemetry.go
@@ -123,6 +123,8 @@ func (h *TelemetryHandler) startTrial(w http.ResponseWriter, r *http.Request) {
 		h.botTelemetry.StartTrialToRestrictPlaybookCreation(userID)
 	case "start_trial_to_restrict_playbook_access":
 		h.botTelemetry.StartTrialToRestrictPlaybookAccess(userID)
+	case "start_trial_to_export_channel":
+		h.botTelemetry.StartTrialToExportChannel(userID)
 	default:
 		h.HandleError(w, errors.New("unknown action"))
 		return

--- a/server/bot/bot.go
+++ b/server/bot/bot.go
@@ -71,11 +71,13 @@ type Telemetry interface {
 	NotifyAdminsToCreatePlaybook(userID string)
 	NotifyAdminsToRestrictPlaybookCreation(userID string)
 	NotifyAdminsToRestrictPlaybookAccess(userID string)
+	NotifyAdminsToExportChannel(userID string)
 	StartTrialToViewTimeline(userID string)
 	StartTrialToAddMessageToTimeline(userID string)
 	StartTrialToCreatePlaybook(userID string)
 	StartTrialToRestrictPlaybookCreation(userID string)
 	StartTrialToRestrictPlaybookAccess(userID string)
+	StartTrialToExportChannel(userID string)
 }
 
 // New creates a new bot poster/logger.

--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -225,6 +225,8 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 		b.telemetry.NotifyAdminsToRestrictPlaybookAccess(authorUserID)
 	case "start_trial_to_restrict_playbook_creation":
 		b.telemetry.NotifyAdminsToRestrictPlaybookCreation(authorUserID)
+	case "start_trial_to_export_channel":
+		b.telemetry.NotifyAdminsToExportChannel(authorUserID)
 	}
 
 	return nil

--- a/server/bot/poster.go
+++ b/server/bot/poster.go
@@ -167,6 +167,10 @@ func (b *Bot) NotifyAdmins(messageType, authorUserID string, isTeamEdition bool)
 		message = fmt.Sprintf("@%s requested access to configure who can create playbooks in Incident Collaboration.", author.Username)
 		title = "Control who can create playbooks in Incident Collaboration with Mattermost Enterprise"
 		text = "Playbooks are workflows that your teams and tools should follow, including everything from checklists, actions, templates, and retrospectives. In Mattermost Enterprise you can set playbook permissions for specific users or set a global permission to control which team members can create playbooks.\n" + footer
+	case "start_trial_to_export_channel":
+		message = fmt.Sprintf("@%s requested access to export the playbook run channel.", author.Username)
+		title = "Save the message history of your playbook runs"
+		text = "Export the channel of your playbook run and save it for later analysis. When you upgrade, you can automatically generate and download a CSV file containing all the timestamped messages sent to the channel.\n" + footer
 	}
 
 	actions := []*model.PostAction{

--- a/server/telemetry/noop.go
+++ b/server/telemetry/noop.go
@@ -113,6 +113,10 @@ func (t *NoopTelemetry) StartTrialToRestrictPlaybookCreation(userID string) {
 func (t *NoopTelemetry) StartTrialToRestrictPlaybookAccess(userID string) {
 }
 
+// StartTrialToExportChannel does nothing.
+func (t *NoopTelemetry) StartTrialToExportChannel(userID string) {
+}
+
 // NotifyAdminsToViewTimeline does nothing.
 func (t *NoopTelemetry) NotifyAdminsToViewTimeline(userID string) {
 
@@ -135,5 +139,10 @@ func (t *NoopTelemetry) NotifyAdminsToRestrictPlaybookCreation(userID string) {
 
 // NotifyAdminsToRestrictPlaybookAccess does nothing.
 func (t *NoopTelemetry) NotifyAdminsToRestrictPlaybookAccess(userID string) {
+
+}
+
+// NotifyAdminsToExportChannel does nothing.
+func (t *NoopTelemetry) NotifyAdminsToExportChannel(userID string) {
 
 }

--- a/server/telemetry/rudder.go
+++ b/server/telemetry/rudder.go
@@ -56,6 +56,7 @@ const (
 	actionNotifyAdminsToCreatePlaybook           = "notify_admins_to_create_playbook"
 	actionNotifyAdminsToRestrictPlaybookCreation = "notify_admins_to_restrict_playbook_creation"
 	actionNotifyAdminsToRestrictPlaybookAccess   = "notify_admins_to_restrict_playbook_access"
+	actionNotifyAdminsToExportChannel            = "notify_admins_to_export_channel"
 
 	eventStartTrial                            = "start_trial"
 	actionStartTrialToViewTimeline             = "start_trial_to_view_timeline"
@@ -63,6 +64,7 @@ const (
 	actionStartTrialToCreatePlaybook           = "start_trial_to_create_playbook"
 	actionStartTrialToRestrictPlaybookCreation = "start_trial_to_restrict_playbook_creation"
 	actionStartTrialToRestrictPlaybookAccess   = "start_trial_to_restrict_playbook_access"
+	actionStartTrialToExportChannel            = "start_trial_to_export_channel"
 
 	// telemetryKeyPlaybookRunID records the legacy name used to identify a playbook run via telemetry.
 	telemetryKeyPlaybookRunID = "IncidentID"
@@ -384,39 +386,46 @@ func (t *RudderTelemetry) StartTrialToRestrictPlaybookAccess(userID string) {
 	t.track(eventStartTrial, properties)
 }
 
+func (t *RudderTelemetry) StartTrialToExportChannel(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionStartTrialToExportChannel
+	t.track(eventStartTrial, properties)
+}
+
 func (t *RudderTelemetry) NotifyAdminsToViewTimeline(userID string) {
 	properties := commonProperties(userID)
 	properties["Action"] = actionNotifyAdminsToViewTimeline
 	t.track(eventNotifyAdmins, properties)
-
 }
 
 func (t *RudderTelemetry) NotifyAdminsToAddMessageToTimeline(userID string) {
 	properties := commonProperties(userID)
 	properties["Action"] = actionNotifyAdminsToAddMessageToTimeline
 	t.track(eventNotifyAdmins, properties)
-
 }
 
 func (t *RudderTelemetry) NotifyAdminsToCreatePlaybook(userID string) {
 	properties := commonProperties(userID)
 	properties["Action"] = actionNotifyAdminsToCreatePlaybook
 	t.track(eventNotifyAdmins, properties)
-
 }
 
 func (t *RudderTelemetry) NotifyAdminsToRestrictPlaybookCreation(userID string) {
 	properties := commonProperties(userID)
 	properties["Action"] = actionNotifyAdminsToRestrictPlaybookCreation
 	t.track(eventNotifyAdmins, properties)
-
 }
 
 func (t *RudderTelemetry) NotifyAdminsToRestrictPlaybookAccess(userID string) {
 	properties := commonProperties(userID)
 	properties["Action"] = actionNotifyAdminsToRestrictPlaybookAccess
 	t.track(eventNotifyAdmins, properties)
+}
 
+func (t *RudderTelemetry) NotifyAdminsToExportChannel(userID string) {
+	properties := commonProperties(userID)
+	properties["Action"] = actionNotifyAdminsToExportChannel
+	t.track(eventNotifyAdmins, properties)
 }
 
 // Enable creates a new client to track all future events. It does nothing if

--- a/webapp/src/components/backstage/upgrade_modal_data.tsx
+++ b/webapp/src/components/backstage/upgrade_modal_data.tsx
@@ -155,6 +155,10 @@ export const getUpgradeModalCopy = (
             titleText = 'Put your team in control';
             helpText = 'Every team\'s structure is different. You can manage which users in the team can create playbooks.';
             break;
+        case AdminNotificationType.EXPORT_CHANNEL:
+            titleText = 'Save your playbook run history';
+            helpText = 'Export the channel of your playbook run and save it for later analysis.';
+            break;
         }
 
         if (!isAdmin) {

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -23,4 +23,5 @@ export enum AdminNotificationType {
     MESSAGE_TO_TIMELINE = 'start_trial_to_add_message_to_timeline',
     PLAYBOOK_GRANULAR_ACCESS = 'start_trial_to_restrict_playbook_access',
     PLAYBOOK_CREATION_RESTRICTION = 'start_trial_to_restrict_playbook_creation',
+    EXPORT_CHANNEL = 'start_trial_to_export_channel',
 }

--- a/webapp/src/hooks.ts
+++ b/webapp/src/hooks.ts
@@ -269,6 +269,11 @@ export function useAllowPlaybookCreationRestriction() {
     return useSelector(isE20LicensedOrDevelopment);
 }
 
+// useAllowChannelExport returns whether exporting the channel is allowed
+export function useAllowChannelExport() {
+    return useSelector(isE20LicensedOrDevelopment);
+}
+
 export function useEnsureProfiles(userIds: string[]) {
     const dispatch = useDispatch();
     type StringToUserProfileFn = (id: string) => UserProfile;

--- a/webapp/src/selectors.ts
+++ b/webapp/src/selectors.ts
@@ -87,12 +87,6 @@ export const myPlaybookRunsMap = (state: GlobalState) => {
     return myPlaybookRunsByTeam(state)[getCurrentTeamId(state)] || {};
 };
 
-export const isExportLicensed = (state: GlobalState): boolean => {
-    const license = getLicense(state);
-
-    return license?.IsLicensed === 'true' && license?.MessageExport === 'true';
-};
-
 export const currentRHSState = (state: GlobalState): RHSState => pluginState(state).rhsState;
 
 export const currentRHSTabState = (state: GlobalState): RHSTabState => {


### PR DESCRIPTION
#### Summary

This PR modifies the Export channel button in the run details screen to match the UI/UX of all other restricted features.

The button is no longer disabled when the server is not properly licensed, but the usual green key icon is shown:

![image](https://user-images.githubusercontent.com/3924815/123703712-0c06c980-d865-11eb-9726-0d5a071943e5.png)

When clicking on it, we get the usual upgrade modal:

| System Admin 	| End user 	|
|-	|-	|
| ![image](https://user-images.githubusercontent.com/3924815/123703737-1759f500-d865-11eb-884f-42d2035593e4.png) 	| ![image](https://user-images.githubusercontent.com/3924815/123703748-1a54e580-d865-11eb-8ba0-f9b1da2c8186.png) 	|

And clicking on Notify Admin sends the usual message to the System Admins:

| Self-managed 	| Cloud 	|
|-	|-	|
| ![image](https://user-images.githubusercontent.com/3924815/123703782-23de4d80-d865-11eb-9816-ea2e314fe21b.png) 	| ![image](https://user-images.githubusercontent.com/3924815/123703789-2640a780-d865-11eb-8606-10190a205b48.png) 	|

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36689

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [X] Telemetry updated
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
