### PR TITLE
Adminify settings

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -40,6 +40,8 @@ type Client struct {
 	PlaybookRuns *PlaybookRunService
 	// Playbooks is a collection of methods used to interact with playbooks.
 	Playbooks *PlaybooksService
+	// Settings is a collection of methods used to interact with settings.
+	Settings *SettingsService
 }
 
 // New creates a new instance of Client using the configuration from the given Mattermost Client.
@@ -62,6 +64,7 @@ func newClient(mattermostSiteURL string, httpClient *http.Client) (*Client, erro
 	c := &Client{client: httpClient, BaseURL: siteURL, UserAgent: userAgent}
 	c.PlaybookRuns = &PlaybookRunService{c}
 	c.Playbooks = &PlaybooksService{c}
+	c.Settings = &SettingsService{c}
 	return c, nil
 }
 

--- a/client/settings.go
+++ b/client/settings.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client
+
+import (
+	"context"
+	"net/http"
+)
+
+type GlobalSettings struct {
+	// PlaybookCreatorsUserIds is an array of user ids authorized to create new playbooks.
+	PlaybookCreatorsUserIds []string `json:"playbook_creators_user_ids"`
+
+	// EnableExperimentalFeatures is a read-only field set to true when experimental features
+	// are enabled. Changing this field requires access to the system console plugin
+	// configuration.
+	EnableExperimentalFeatures bool `json:"enable_experimental_features"`
+}
+
+// SettingsService handles communication with the settings related methods.
+type SettingsService struct {
+	client *Client
+}
+
+// Get the configured settings.
+func (s *SettingsService) Get(ctx context.Context) (*GlobalSettings, error) {
+	settingsURL := "settings"
+	req, err := s.client.newRequest(http.MethodGet, settingsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	settings := new(GlobalSettings)
+	resp, err := s.client.do(ctx, req, settings)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+
+	return settings, nil
+}
+
+// Update the configured settings.
+func (s *SettingsService) Update(ctx context.Context, settings GlobalSettings) error {
+	settingsURL := "settings"
+	req, err := s.client.newRequest(http.MethodPost, settingsURL, settings)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/client/settings.go
+++ b/client/settings.go
@@ -44,7 +44,7 @@ func (s *SettingsService) Get(ctx context.Context) (*GlobalSettings, error) {
 // Update the configured settings.
 func (s *SettingsService) Update(ctx context.Context, settings GlobalSettings) error {
 	settingsURL := "settings"
-	req, err := s.client.newRequest(http.MethodPost, settingsURL, settings)
+	req, err := s.client.newRequest(http.MethodPut, settingsURL, settings)
 	if err != nil {
 		return err
 	}

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/bot"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/app"
 	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/config"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
@@ -43,59 +42,11 @@ func NewHandler(pluginAPI *pluginapi.Client, config config.Service, log bot.Logg
 	handler.root = root
 	handler.config = config
 
-	settingsRouter := handler.APIRouter.PathPrefix("/settings").Subrouter()
-	settingsRouter.HandleFunc("", handler.getSettings).Methods(http.MethodGet)
-	settingsRouter.HandleFunc("", handler.setSettings).Methods(http.MethodPost)
-
 	return handler
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.root.ServeHTTP(w, r)
-}
-
-type GlobalSettings struct {
-	PlaybookCreatorsUserIds    []string `json:"playbook_creators_user_ids"`
-	EnableExperimentalFeatures bool     `json:"enable_experimental_features"`
-}
-
-func (h *Handler) getSettings(w http.ResponseWriter, r *http.Request) {
-	cfg := h.config.GetConfiguration()
-	settings := GlobalSettings{
-		PlaybookCreatorsUserIds:    cfg.PlaybookCreatorsUserIds,
-		EnableExperimentalFeatures: cfg.EnableExperimentalFeatures,
-	}
-	ReturnJSON(w, &settings, http.StatusOK)
-}
-
-func (h *Handler) setSettings(w http.ResponseWriter, r *http.Request) {
-	userID := r.Header.Get("Mattermost-User-ID")
-
-	var settings GlobalSettings
-	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
-		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode settings", err)
-		return
-	}
-
-	if err := app.ModifySettings(userID, h.config); err != nil {
-		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
-		return
-	}
-
-	if !h.config.IsAtLeastE20Licensed() {
-		if len(settings.PlaybookCreatorsUserIds) > 0 {
-			h.HandleErrorWithCode(w, http.StatusForbidden, "unlicensed servers cannot configure specific users to access playbooks", nil)
-			return
-		}
-	}
-
-	pluginConfig := h.pluginAPI.Configuration.GetPluginConfig()
-	pluginConfig["PlaybookCreatorsUserIds"] = settings.PlaybookCreatorsUserIds
-	if err := h.pluginAPI.Configuration.SavePluginConfig(pluginConfig); err != nil {
-		h.HandleError(w, err)
-	}
-
-	w.WriteHeader(http.StatusOK)
 }
 
 // HandleErrorWithCode logs the internal error and sends the public facing error

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -57,7 +57,7 @@ func (h *SettingsHandler) setSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	isAdmin := app.IsAdmin(userID, h.pluginAPI)
-	if err := app.ModifySettings(userID, isAdmin, h.config); err != nil {
+	if err := app.ModifyPlaybookCreators(userID, isAdmin, h.config); err != nil {
 		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
 		return
 	}

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -56,7 +56,8 @@ func (h *SettingsHandler) setSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.ModifySettings(userID, h.config); err != nil {
+	isAdmin := app.IsAdmin(userID, h.pluginAPI)
+	if err := app.ModifySettings(userID, isAdmin, h.config); err != nil {
 		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
 		return
 	}

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/client"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/app"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/bot"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/config"
+
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+)
+
+// SettingsHandler is the API handler.
+type SettingsHandler struct {
+	*ErrorHandler
+	pluginAPI *pluginapi.Client
+	log       bot.Logger
+	config    config.Service
+}
+
+// NewSettingsHandler returns a new settings api handler
+func NewSettingsHandler(router *mux.Router, api *pluginapi.Client, log bot.Logger, configService config.Service) *SettingsHandler {
+	handler := &SettingsHandler{
+		ErrorHandler: &ErrorHandler{log: log},
+		pluginAPI:    api,
+		log:          log,
+		config:       configService,
+	}
+
+	settingsRouter := router.PathPrefix("/settings").Subrouter()
+	settingsRouter.HandleFunc("", handler.getSettings).Methods(http.MethodGet)
+	settingsRouter.HandleFunc("", handler.setSettings).Methods(http.MethodPost)
+
+	return handler
+}
+
+func (h *SettingsHandler) getSettings(w http.ResponseWriter, r *http.Request) {
+	cfg := h.config.GetConfiguration()
+	settings := client.GlobalSettings{
+		PlaybookCreatorsUserIds:    cfg.PlaybookCreatorsUserIds,
+		EnableExperimentalFeatures: cfg.EnableExperimentalFeatures,
+	}
+
+	ReturnJSON(w, &settings, http.StatusOK)
+}
+
+func (h *SettingsHandler) setSettings(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+
+	var settings client.GlobalSettings
+	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+		h.HandleErrorWithCode(w, http.StatusBadRequest, "unable to decode settings", err)
+		return
+	}
+
+	if err := app.ModifySettings(userID, h.config); err != nil {
+		h.HandleErrorWithCode(w, http.StatusForbidden, "Not authorized", err)
+		return
+	}
+
+	if !h.config.IsAtLeastE20Licensed() {
+		if len(settings.PlaybookCreatorsUserIds) > 0 {
+			h.HandleErrorWithCode(w, http.StatusForbidden, "unlicensed servers cannot configure specific users to access playbooks", nil)
+			return
+		}
+	}
+
+	pluginConfig := h.pluginAPI.Configuration.GetPluginConfig()
+	pluginConfig["PlaybookCreatorsUserIds"] = settings.PlaybookCreatorsUserIds
+	if err := h.pluginAPI.Configuration.SavePluginConfig(pluginConfig); err != nil {
+		h.HandleError(w, err)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -32,7 +32,7 @@ func NewSettingsHandler(router *mux.Router, api *pluginapi.Client, log bot.Logge
 
 	settingsRouter := router.PathPrefix("/settings").Subrouter()
 	settingsRouter.HandleFunc("", handler.getSettings).Methods(http.MethodGet)
-	settingsRouter.HandleFunc("", handler.setSettings).Methods(http.MethodPost)
+	settingsRouter.HandleFunc("", handler.setSettings).Methods(http.MethodPut)
 
 	return handler
 }

--- a/server/api/settings_test.go
+++ b/server/api/settings_test.go
@@ -1,0 +1,380 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	icClient "github.com/mattermost/mattermost-plugin-incident-collaboration/client"
+	mock_poster "github.com/mattermost/mattermost-plugin-incident-collaboration/server/bot/mocks"
+	"github.com/mattermost/mattermost-plugin-incident-collaboration/server/config"
+	mock_config "github.com/mattermost/mattermost-plugin-incident-collaboration/server/config/mocks"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/require"
+
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+)
+
+func TestGetSettings(t *testing.T) {
+	var mockCtrl *gomock.Controller
+	var handler *Handler
+	var logger *mock_poster.MockLogger
+	var configService *mock_config.MockService
+	var pluginAPI *plugintest.API
+	var client *pluginapi.Client
+
+	mattermostUserID := "testuserid"
+
+	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
+	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.Header.Add("Mattermost-User-ID", mattermostUserID)
+
+		handler.ServeHTTP(w, r)
+	})
+
+	server := httptest.NewServer(mattermostHandler)
+	t.Cleanup(server.Close)
+
+	c, err := icClient.New(&model.Client4{Url: server.URL})
+	require.NoError(t, err)
+
+	reset := func(t *testing.T) {
+		t.Helper()
+
+		mattermostUserID = "testuserid"
+		mockCtrl = gomock.NewController(t)
+		configService = mock_config.NewMockService(mockCtrl)
+		pluginAPI = &plugintest.API{}
+		client = pluginapi.NewClient(pluginAPI, &plugintest.Driver{})
+		logger = mock_poster.NewMockLogger(mockCtrl)
+		handler = NewHandler(client, configService, logger)
+		logger = mock_poster.NewMockLogger(mockCtrl)
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+	}
+
+	t.Run("get settings, unauthenticated", func(t *testing.T) {
+		reset(t)
+		mattermostUserID = ""
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		settings, err := c.Settings.Get(context.TODO())
+		requireErrorWithStatusCode(t, err, http.StatusUnauthorized)
+		require.Nil(t, settings)
+	})
+
+	t.Run("get settings, empty", func(t *testing.T) {
+		reset(t)
+
+		expectedSettings := &icClient.GlobalSettings{
+			PlaybookCreatorsUserIds:    []string{},
+			EnableExperimentalFeatures: false,
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&config.Configuration{
+				PlaybookCreatorsUserIds:    expectedSettings.PlaybookCreatorsUserIds,
+				EnableExperimentalFeatures: expectedSettings.EnableExperimentalFeatures,
+				EnabledTeams:               []string{"not exposed"},
+			})
+
+		settings, err := c.Settings.Get(context.TODO())
+		require.NoError(t, err)
+		require.Equal(t, expectedSettings, settings)
+	})
+
+	t.Run("get settings, populated", func(t *testing.T) {
+		reset(t)
+
+		expectedSettings := &icClient.GlobalSettings{
+			PlaybookCreatorsUserIds:    []string{model.NewId(), model.NewId()},
+			EnableExperimentalFeatures: true,
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&config.Configuration{
+				PlaybookCreatorsUserIds:    expectedSettings.PlaybookCreatorsUserIds,
+				EnableExperimentalFeatures: expectedSettings.EnableExperimentalFeatures,
+				EnabledTeams:               []string{"not exposed"},
+			})
+
+		settings, err := c.Settings.Get(context.TODO())
+		require.NoError(t, err)
+		require.Equal(t, expectedSettings, settings)
+	})
+}
+
+func TestSetSettings(t *testing.T) {
+	var mockCtrl *gomock.Controller
+	var handler *Handler
+	var logger *mock_poster.MockLogger
+	var configService *mock_config.MockService
+	var pluginAPI *plugintest.API
+	var client *pluginapi.Client
+
+	mattermostUserID := "testuserid"
+
+	// mattermostHandler simulates the Mattermost server routing HTTP requests to a plugin.
+	mattermostHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/plugins/com.mattermost.plugin-incident-management")
+		r.Header.Add("Mattermost-User-ID", mattermostUserID)
+
+		handler.ServeHTTP(w, r)
+	})
+
+	server := httptest.NewServer(mattermostHandler)
+	t.Cleanup(server.Close)
+
+	c, err := icClient.New(&model.Client4{Url: server.URL})
+	require.NoError(t, err)
+
+	reset := func(t *testing.T) {
+		t.Helper()
+
+		mattermostUserID = "testuserid"
+		mockCtrl = gomock.NewController(t)
+		configService = mock_config.NewMockService(mockCtrl)
+		pluginAPI = &plugintest.API{}
+		client = pluginapi.NewClient(pluginAPI, &plugintest.Driver{})
+		logger = mock_poster.NewMockLogger(mockCtrl)
+		handler = NewHandler(client, configService, logger)
+		logger = mock_poster.NewMockLogger(mockCtrl)
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+	}
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		reset(t)
+		mattermostUserID = ""
+
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds:    []string{},
+			EnableExperimentalFeatures: false,
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		err := c.Settings.Update(context.TODO(), settings)
+		requireErrorWithStatusCode(t, err, http.StatusUnauthorized)
+	})
+
+	t.Run("not a playbook creator", func(t *testing.T) {
+		reset(t)
+
+		existingConfiguration := config.Configuration{
+			PlaybookCreatorsUserIds:    []string{model.NewId()},
+			EnableExperimentalFeatures: false,
+		}
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds: append(
+				existingConfiguration.PlaybookCreatorsUserIds,
+				mattermostUserID,
+			),
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&existingConfiguration)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
+
+		err := c.Settings.Update(context.TODO(), settings)
+		requireErrorWithStatusCode(t, err, http.StatusForbidden)
+	})
+
+	t.Run("not licensed, no-op settings change", func(t *testing.T) {
+		reset(t)
+
+		existingConfiguration := config.Configuration{
+			PlaybookCreatorsUserIds:    []string{},
+			EnableExperimentalFeatures: false,
+			AllowedUserIDs:             []string{},
+		}
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds: []string{},
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&existingConfiguration)
+		configService.EXPECT().
+			IsAtLeastE20Licensed().
+			Return(false)
+		pluginAPI.On("GetPluginConfig").Return(map[string]interface{}{})
+		pluginAPI.On("SavePluginConfig", map[string]interface{}{
+			"PlaybookCreatorsUserIds": []string{},
+		}).Return(nil)
+
+		err := c.Settings.Update(context.TODO(), settings)
+		require.NoError(t, err)
+	})
+
+	t.Run("not licensed, trying to set playbook creators for first time", func(t *testing.T) {
+		reset(t)
+
+		existingConfiguration := config.Configuration{
+			PlaybookCreatorsUserIds:    []string{},
+			EnableExperimentalFeatures: false,
+			AllowedUserIDs:             []string{},
+		}
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds: []string{mattermostUserID},
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&existingConfiguration)
+		configService.EXPECT().
+			IsAtLeastE20Licensed().
+			Return(false)
+		logger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
+
+		err := c.Settings.Update(context.TODO(), settings)
+		requireErrorWithStatusCode(t, err, http.StatusForbidden)
+	})
+
+	t.Run("set settings, licensed, settings playbook creators for the first time", func(t *testing.T) {
+		reset(t)
+
+		existingConfiguration := config.Configuration{
+			PlaybookCreatorsUserIds:    []string{},
+			EnableExperimentalFeatures: false,
+			AllowedUserIDs:             []string{},
+		}
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds: []string{mattermostUserID},
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&existingConfiguration)
+		configService.EXPECT().
+			IsAtLeastE20Licensed().
+			Return(true)
+		pluginAPI.On("GetPluginConfig").Return(make(map[string]interface{}))
+		pluginAPI.On("SavePluginConfig", map[string]interface{}{
+			"PlaybookCreatorsUserIds": []string{mattermostUserID},
+		}).Return(nil)
+
+		err := c.Settings.Update(context.TODO(), settings)
+		require.NoError(t, err)
+	})
+
+	t.Run("set settings, licensed, adding another user", func(t *testing.T) {
+		reset(t)
+
+		newUserID := model.NewId()
+		existingConfiguration := config.Configuration{
+			PlaybookCreatorsUserIds:    []string{mattermostUserID},
+			EnableExperimentalFeatures: false,
+			AllowedUserIDs:             []string{},
+		}
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds: []string{mattermostUserID, newUserID},
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&existingConfiguration)
+		configService.EXPECT().
+			IsAtLeastE20Licensed().
+			Return(true)
+		pluginAPI.On("GetPluginConfig").Return(make(map[string]interface{}))
+		pluginAPI.On("SavePluginConfig", map[string]interface{}{
+			"PlaybookCreatorsUserIds": []string{mattermostUserID, newUserID},
+		}).Return(nil)
+
+		err := c.Settings.Update(context.TODO(), settings)
+		require.NoError(t, err)
+	})
+
+	t.Run("set settings, licensed, assigning to someone else", func(t *testing.T) {
+		reset(t)
+
+		otherUserID := model.NewId()
+		existingConfiguration := config.Configuration{
+			PlaybookCreatorsUserIds:    []string{mattermostUserID},
+			EnableExperimentalFeatures: false,
+			AllowedUserIDs:             []string{},
+		}
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds: []string{otherUserID},
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&existingConfiguration)
+		configService.EXPECT().
+			IsAtLeastE20Licensed().
+			Return(true)
+		pluginAPI.On("GetPluginConfig").Return(make(map[string]interface{}))
+		pluginAPI.On("SavePluginConfig", map[string]interface{}{
+			"PlaybookCreatorsUserIds": []string{otherUserID},
+		}).Return(nil)
+
+		err := c.Settings.Update(context.TODO(), settings)
+		require.NoError(t, err)
+	})
+
+	t.Run("set settings, licensed, removing all users", func(t *testing.T) {
+		reset(t)
+
+		otherUserID := model.NewId()
+		existingConfiguration := config.Configuration{
+			PlaybookCreatorsUserIds:    []string{mattermostUserID, otherUserID},
+			EnableExperimentalFeatures: false,
+			AllowedUserIDs:             []string{},
+		}
+		settings := icClient.GlobalSettings{
+			PlaybookCreatorsUserIds: []string{},
+		}
+
+		NewSettingsHandler(handler.APIRouter, client, logger, configService)
+
+		configService.EXPECT().
+			GetConfiguration().
+			AnyTimes().
+			Return(&existingConfiguration)
+		configService.EXPECT().
+			IsAtLeastE20Licensed().
+			Return(true)
+		pluginAPI.On("GetPluginConfig").Return(make(map[string]interface{}))
+		pluginAPI.On("SavePluginConfig", map[string]interface{}{
+			"PlaybookCreatorsUserIds": []string{},
+		}).Return(nil)
+
+		err := c.Settings.Update(context.TODO(), settings)
+		require.NoError(t, err)
+	})
+}

--- a/server/app/permissions.go
+++ b/server/app/permissions.go
@@ -351,7 +351,7 @@ func ModifyPlaybookCreators(userID string, isAdmin bool, config config.Service) 
 	cfg := config.GetConfiguration()
 
 	// Only admins are allowed to initially modify the settings.
-	if len(cfg.PlaybookCreatorsUserIds) == 0 && !isAdmin {
+	if len(cfg.PlaybookCreatorsUserIds) == 0 {
 		return errors.Wrap(ErrNoPermissions, "only system admins may initially constrain playbook creators")
 	}
 

--- a/server/app/permissions.go
+++ b/server/app/permissions.go
@@ -342,7 +342,7 @@ func PlaybookModify(userID string, playbook, oldPlaybook Playbook, cfgService co
 	return nil
 }
 
-func ModifySettings(userID string, isAdmin bool, config config.Service) error {
+func ModifyPlaybookCreators(userID string, isAdmin bool, config config.Service) error {
 	// Admins are always allowed to modify settings.
 	if isAdmin {
 		return nil

--- a/server/app/permissions.go
+++ b/server/app/permissions.go
@@ -342,21 +342,24 @@ func PlaybookModify(userID string, playbook, oldPlaybook Playbook, cfgService co
 	return nil
 }
 
-func ModifySettings(userID string, config config.Service) error {
-	cfg := config.GetConfiguration()
-	if len(cfg.PlaybookCreatorsUserIds) > 0 {
-		found := false
-		for _, candidateUserID := range cfg.PlaybookCreatorsUserIds {
-			if candidateUserID == userID {
-				found = true
-				break
-			}
-		}
+func ModifySettings(userID string, isAdmin bool, config config.Service) error {
+	// Admins are always allowed to modify settings.
+	if isAdmin {
+		return nil
+	}
 
-		if !found {
-			return errors.Wrap(ErrNoPermissions, "not a playbook creator")
+	cfg := config.GetConfiguration()
+
+	// Only admins are allowed to initially modify the settings.
+	if len(cfg.PlaybookCreatorsUserIds) == 0 && !isAdmin {
+		return errors.Wrap(ErrNoPermissions, "only system admins may initially constrain playbook creators")
+	}
+
+	for _, candidateUserID := range cfg.PlaybookCreatorsUserIds {
+		if candidateUserID == userID {
+			return nil
 		}
 	}
 
-	return nil
+	return errors.Wrap(ErrNoPermissions, "not a playbook creator")
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -179,6 +179,7 @@ func (p *Plugin) OnActivate() error {
 	api.NewBotHandler(p.handler.APIRouter, pluginAPIClient, p.bot, p.bot, p.config)
 	api.NewTelemetryHandler(p.handler.APIRouter, p.playbookRunService, pluginAPIClient, p.bot, telemetryClient, telemetryClient, p.config)
 	api.NewSignalHandler(p.handler.APIRouter, pluginAPIClient, p.bot, p.playbookRunService, p.playbookService, keywordsThreadIgnorer)
+	api.NewSettingsHandler(p.handler.APIRouter, pluginAPIClient, p.bot, p.config)
 
 	isTestingEnabled := false
 	flag := p.API.GetConfig().ServiceSettings.EnableTesting

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -306,7 +306,7 @@ export async function telemetryEventForPlaybookRun(playbookRunID: string, action
 
 export async function setGlobalSettings(settings: GlobalSettings) {
     await doFetchWithoutResponse(`${apiUrl}/settings`, {
-        method: 'POST',
+        method: 'PUT',
         body: JSON.stringify(settings),
     });
 }

--- a/webapp/src/components/backstage/styles.tsx
+++ b/webapp/src/components/backstage/styles.tsx
@@ -23,7 +23,7 @@ export const BackstageHeader = styled.div`
     font-size: 2.8rem;
     line-height: 3.6rem;
     align-items: center;
-    margin: 4rem 1rem 3.2rem;
+    padding: 4rem 0 3.2rem;
 `;
 
 export const TeamContainer = styled.div`

--- a/webapp/src/hooks.ts
+++ b/webapp/src/hooks.ts
@@ -26,7 +26,7 @@ import {clientFetchPlaybooksCount} from 'src/client';
 import {receivedTeamNumPlaybooks} from 'src/actions';
 
 import {isCloud, isE10LicensedOrDevelopment, isE20LicensedOrDevelopment} from './license';
-import {currentTeamNumPlaybooks, globalSettings} from './selectors';
+import {currentTeamNumPlaybooks, globalSettings, isCurrentUserAdmin} from './selectors';
 
 export function useCurrentTeamPermission(options: PermissionsOptions): boolean {
     const currentTeam = useSelector<GlobalState, Team>(getCurrentTeam);
@@ -153,6 +153,24 @@ export function useCanCreatePlaybooks() {
 
     // No restrictions if length is zero
     if (settings.playbook_creators_user_ids.length === 0) {
+        return true;
+    }
+
+    return settings.playbook_creators_user_ids.includes(currentUserID);
+}
+
+export function useCanRestrictPlaybookCreation() {
+    const settings = useSelector(globalSettings);
+    const isAdmin = useSelector(isCurrentUserAdmin);
+    const currentUserID = useSelector(getCurrentUserId);
+
+    // This is really a loading state so just assume no.
+    if (!settings) {
+        return false;
+    }
+
+    // No restrictions if user is a system administrator.
+    if (isAdmin) {
         return true;
     }
 


### PR DESCRIPTION
#### Summary
Always allow system administrators to configure who can create playbooks. I took the liberty of refactoring the settings handler and extending the client API accordingly. (Feel free to review by commit!)

As the admin user `test`, I can still configure this:

<img width="483" alt="image" src="https://user-images.githubusercontent.com/1023171/123705994-0f3a8f00-d83e-11eb-8676-e60151f54c45.png">

As the non-admin user `test2`, I can't:

<img width="762" alt="image" src="https://user-images.githubusercontent.com/1023171/123706022-18c3f700-d83e-11eb-8a3d-e34249f95d17.png">

When there are no restrictions, the non-admin user `test2` can't (but `test` can!):

<img width="716" alt="image" src="https://user-images.githubusercontent.com/1023171/123706094-37c28900-d83e-11eb-9cbd-fc1fa686d3aa.png">


#### Ticket Link
None.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
