### PR TITLE
MM-36540 - Improve graph searching & polish

### DIFF
--- a/server/sqlstore/stats.go
+++ b/server/sqlstore/stats.go
@@ -191,8 +191,8 @@ func (s *StatsStore) MovingWindowQueryActive(query sq.SelectBuilder, numDays int
 func (s *StatsStore) RunsStartedPerWeekLastXWeeks(x int, filters *StatsFilters) ([]int, []string, [][]int64) {
 	day := int64(86400000)
 	week := day * 7
-	startOfWeek := beginningOfTodayMillis() - week
-	endOfWeek := endOfTodayMillis()
+	startOfWeek := beginningOfLastSundayMillis()
+	endOfWeek := startOfWeek + week - 1
 	var weeksAsStrings []string
 	var weeksStartAndEnd [][]int64
 
@@ -591,7 +591,15 @@ func beginningOfTodayMillis() int64 {
 func endOfTodayMillis() int64 {
 	year, month, day := time.Now().UTC().Add(24 * time.Hour).Date()
 	bod := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	return bod.UnixNano() / int64(time.Millisecond)
+	return bod.UnixNano()/int64(time.Millisecond) - 1
+}
+
+func beginningOfLastSundayMillis() int64 {
+	// Weekday is an iota where Sun = 0, Mon = 1, etc. So this is an offset to get back to Sun.
+	offset := int(time.Now().UTC().Weekday())
+	now := time.Now().UTC()
+	startOfSunday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -offset)
+	return startOfSunday.UnixNano() / int64(time.Millisecond)
 }
 
 func reverseSlice(s interface{}) {

--- a/webapp/src/components/assets/icons/clear_icon.tsx
+++ b/webapp/src/components/assets/icons/clear_icon.tsx
@@ -1,13 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
 
-import React from 'react';
 import styled from 'styled-components';
 
-const ClearIcon = (props: React.PropsWithoutRef<JSX.IntrinsicElements['i']>): JSX.Element => (
-    <i className={`icon icon-close-circle ${props.className}`}/>
-);
-
-export default styled(ClearIcon)`
+export default styled.i.attrs(() => ({className: 'icon icon-close-circle'}))`
     color: rgba(var(--center-channel-color-rgb), 0.56);
 `;

--- a/webapp/src/components/backstage/playbooks/bar_graph.tsx
+++ b/webapp/src/components/backstage/playbooks/bar_graph.tsx
@@ -39,6 +39,9 @@ const BarGraph = (props: BarGraphProps) => {
                     scales: {
                         yAxes: [{
                             ticks: {
+                                callback: (val: any) => {
+                                    return (val % 1 === 0) ? val : null;
+                                },
                                 beginAtZero: true,
                                 fontColor: centerChannelFontColor,
                             },

--- a/webapp/src/components/backstage/playbooks/bar_graph.tsx
+++ b/webapp/src/components/backstage/playbooks/bar_graph.tsx
@@ -85,6 +85,11 @@ const BarGraph = (props: BarGraphProps) => {
                         // eslint-disable-next-line no-underscore-dangle
                         props.onClick(element[0]._index);
                     },
+                    onHover(event: any) {
+                        if (props.onClick) {
+                            event.target.style.cursor = 'pointer';
+                        }
+                    },
                     maintainAspectRatio: false,
                     responsive: true,
                 }}

--- a/webapp/src/components/backstage/playbooks/line_graph.tsx
+++ b/webapp/src/components/backstage/playbooks/line_graph.tsx
@@ -86,6 +86,11 @@ const LineGraph = (props: LineGraphProps) => {
                         // eslint-disable-next-line no-underscore-dangle
                         props.onClick(element[0]._index);
                     },
+                    onHover(event: any) {
+                        if (props.onClick) {
+                            event.target.style.cursor = 'pointer';
+                        }
+                    },
                     maintainAspectRatio: false,
                     responsive: true,
                 }}

--- a/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_backstage.tsx
@@ -37,6 +37,7 @@ const PlaybookBackstage = () => {
     const currentTeam = useSelector(getCurrentTeam);
     const [playbook, setPlaybook] = useState<Playbook | null>(null);
     const [fetchParamsTime, setFetchParamsTime] = useState(DefaultFetchPlaybookRunsParamsTime);
+    const [filterPill, setFilterPill] = useState<JSX.Element | null>(null);
     const [fetchingState, setFetchingState] = useState(FetchingStateType.loading);
     const [stats, setStats] = useState(EmptyPlaybookStats);
 
@@ -119,10 +120,12 @@ const PlaybookBackstage = () => {
                         stats={stats}
                         fetchParamsTime={fetchParamsTime}
                         setFetchParamsTime={setFetchParamsTime}
+                        setFilterPill={setFilterPill}
                     />
                     <PlaybookRunList
                         playbook={playbook}
                         fetchParamsTime={fetchParamsTime}
+                        filterPill={filterPill}
                     />
                 </BottomInnerContainer>
             </BottomContainer>

--- a/webapp/src/components/backstage/playbooks/playbook_run_list/playbook_run_list.tsx
+++ b/webapp/src/components/backstage/playbooks/playbook_run_list/playbook_run_list.tsx
@@ -72,6 +72,7 @@ const statusOptions: StatusOption[] = [
 interface Props {
     playbook: Playbook | null
     fetchParamsTime?: FetchPlaybookRunsParamsTime
+    filterPill?: JSX.Element | null
 }
 
 const PlaybookRunList = (props: Props) => {
@@ -208,6 +209,7 @@ const PlaybookRunList = (props: Props) => {
                         onChange={setStatus}
                     />
                 </div>
+                {props.filterPill}
                 <PlaybookRunListHeader>
                     <div className='row'>
                         <div className='col-sm-4'>

--- a/webapp/src/components/widgets/pill.tsx
+++ b/webapp/src/components/widgets/pill.tsx
@@ -28,7 +28,7 @@ const PillBox = styled.div`
     font-weight: normal;
     font-size: 14px;
     line-height: 15px;
-    padding: 4px 4px 5px 12px;
+    padding: 4px 4px 4px 12px;
 `;
 
 const CloseIcon = styled(ClearIcon)`

--- a/webapp/src/components/widgets/pill.tsx
+++ b/webapp/src/components/widgets/pill.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import styled from 'styled-components';
+
+import ClearIcon from 'src/components/assets/icons/clear_icon';
+
+interface Props {
+    text: string;
+    onClose: () => void;
+}
+
+const Pill = (props: Props) => {
+    return (
+        <PillBox>
+            {props.text}
+            <CloseIcon onClick={props.onClose}/>
+        </PillBox>
+    );
+};
+
+const PillBox = styled.div`
+    display: inline-block;
+    background-color: rgba(var(--center-channel-color-rgb), 0.08);
+    color: var(--center-channel-color);
+    border-radius: 16px;
+    font-weight: normal;
+    font-size: 14px;
+    line-height: 15px;
+    padding: 4px 4px 5px 12px;
+`;
+
+const CloseIcon = styled(ClearIcon)`
+    height: 18px;
+    width: auto;
+    margin-left: 7px;
+    color: var(--center-channel-color-32);
+
+    &:hover {
+        cursor: pointer;
+    }
+
+    &:active {
+        color: var(--center-channel-color)
+    }
+`;
+
+export default Pill;


### PR DESCRIPTION
#### Summary
- Can review based on commit
- When clicking on the graph, add a pill to indicate that the runs list is being filtered
- Cursor changed to pointer (only on graphs that are clickable)
- Weeks start on Sunday for stats, and end a millisecond before midnight on the last day of the range. Hopefully this will fix the wonky graphs on community.
- Only show whole numbers on the y axis for the line graphs
- Designs: (see the topleftmost design) https://www.figma.com/file/vhVlHvJVNTxW6g9PLLnzI0/Playbook-Details?node-id=2%3A3949

E.g., after clicking on the `Total Runs` graph:
![image](https://user-images.githubusercontent.com/1490756/123858403-7a916900-d8f1-11eb-94a9-268e67100572.png)

E.g., after clicking on the `Active Runs` graph:
![image](https://user-images.githubusercontent.com/1490756/123858520-9e54af00-d8f1-11eb-9ccf-ae973a9c1f1b.png)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-36540

#### Checklist
- [ ] ~~Telemetry updated~~
- [x] Gated by experimental feature flag
- [ ] ~~Unit tests updated~~
