### PR TITLE
MM-36748: Add optional chaining to prevent undefined error

### DIFF
--- a/webapp/src/components/retrospective_reminder_posts.tsx
+++ b/webapp/src/components/retrospective_reminder_posts.tsx
@@ -49,7 +49,7 @@ interface ReminderCommonProps {
     post: Post
 }
 
-const selectLatestReminderPost = (state: GlobalState) => getPostsInCurrentChannel(state)?.find((value: Post) => value.type.startsWith('custom_retro'));
+const selectLatestReminderPost = (state: GlobalState) => getPostsInCurrentChannel(state)?.find((value: Post) => value.type?.startsWith('custom_retro'));
 
 const ReminderCommon = (props: ReminderCommonProps) => {
     const playbookRun = useSelector(currentPlaybookRun);


### PR DESCRIPTION
#### Summary

The `type` property of new posts sent to the channel is undefined, resulting in a crash when looking for the latest reminder post, which assumes this field is a string when calling its `startsWith` method.

This simply makes sure that we don't access that property when undefined, assuming it's not a reminder post (as it's a post manually posted by the user).

Why the new posts have no `type` set is still an unknown to me. Old posts that are loaded when entering the channel do have `type` defined as an empty string.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36748

#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
