### PR TITLE
MM-36768: Allow playbook editing regardless of the license

### DIFF
--- a/server/app/permissions.go
+++ b/server/app/permissions.go
@@ -324,10 +324,6 @@ func PlaybookModify(userID string, playbook, oldPlaybook Playbook, cfgService co
 		return err
 	}
 
-	if err := PlaybookLicensedFeatures(playbook, cfgService, playbookService); err != nil {
-		return err
-	}
-
 	if playbook.BroadcastChannelID != "" &&
 		playbook.BroadcastChannelID != oldPlaybook.BroadcastChannelID &&
 		!pluginAPI.User.HasPermissionToChannel(userID, playbook.BroadcastChannelID, model.PERMISSION_CREATE_POST) {


### PR DESCRIPTION
#### Summary

This PR makes playbook editing possible for all servers, regardless of the license they have.

If a server has more than one playbook in a team and downgrades to the Starter plan, they will still be able to edit and use all the playbooks they had, but I believe that's a good thing. @itao, thoughts?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36768
#### Checklist
<!-- Check off items as they are completed. ~~Strike through~~ items if they don't apply -->
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
