### PR TITLE
MM-36876: useProfilesInChannel should try once

### DIFF
--- a/webapp/src/hooks.ts
+++ b/webapp/src/hooks.ts
@@ -193,7 +193,7 @@ export function useProfilesInChannel(channelId: string) {
         }
 
         dispatch(getProfilesInChannel(channelId, 0, PROFILE_CHUNK_SIZE));
-    }, [channelId, profilesInChannel]);
+    }, [channelId]);
 
     return profilesInChannel;
 }


### PR DESCRIPTION
#### Summary
Change `useProfilesInChannel` to only try getting the profiles in the channel once (or, at least as long as the given `channelId` never changes). Previously, the `profilesInChannel` selector would /always/ result in a new value, triggering the effect hook indefinitely.

Relates-to: https://mattermost.atlassian.net/browse/MM-36876

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36876

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] ~~Unit tests updated~~
