### PR TITLE
stop random scroll on edit playbook

### DIFF
--- a/webapp/src/components/checklist_item_input.tsx
+++ b/webapp/src/components/checklist_item_input.tsx
@@ -95,7 +95,7 @@ export const ChecklistItemDescription = (props: ChecklistItemDescriptionProps) =
         descriptionBox = (
             <>
                 <StyledTextarea
-                    autoFocus={true}
+                    autoFocus={!description}
                     value={description}
                     onBlur={save}
                     placeholder={'Description'}


### PR DESCRIPTION
#### Summary
When editing a playbook, the unconditional `autoFocus=true` on the last visible description forced the page to scroll to that element. Only do this is the description is empty, making it easy to start typing a description when adding one but not scrolling when first loading.

#### Ticket Link
None.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [ ] Unit tests updated
