### PR TITLE
make playbook navbar sticky

### DIFF
--- a/tests-e2e/cypress/support/plugin_ui_commands.js
+++ b/tests-e2e/cypress/support/plugin_ui_commands.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import * as TIMEOUTS from '../fixtures/timeouts';
-
 const playbookRunStartCommand = '/playbook start';
 
 // function startPlaybookRun(playbookRunName) {
@@ -86,7 +84,7 @@ Cypress.Commands.add('startPlaybookRunFromPostMenu', (playbookName, playbookRunN
 });
 
 Cypress.Commands.add('openBackstage', () => {
-    cy.get('#lhsHeader', {timeout: TIMEOUTS.GIGANTIC}).should('exist').within(() => {
+    cy.get('#lhsHeader', {timeout: 120000}).should('exist').within(() => {
         // # Wait until the channel loads enough to show the post textbox.
         cy.get('#post-create').should('exist');
         cy.wait(2000);
@@ -106,7 +104,7 @@ Cypress.Commands.add('openBackstage', () => {
 Cypress.Commands.add('createPlaybook', (teamName, playbookName) => {
     cy.visit(`/${teamName}/com.mattermost.plugin-incident-management/playbooks/new`);
 
-    cy.findByTestId('save_playbook', {timeout: TIMEOUTS.LARGE}).should('exist');
+    cy.findByTestId('save_playbook', {timeout: 30000}).should('exist');
 
     // # Type playbook name
     cy.get('#playbook-name .editable-trigger').click();
@@ -114,9 +112,9 @@ Cypress.Commands.add('createPlaybook', (teamName, playbookName) => {
     cy.get('#playbook-name .editable-input').type('{enter}');
 
     // # Save playbook
-    cy.findByTestId('save_playbook', {timeout: TIMEOUTS.LARGE}).should('not.be.disabled').click();
+    cy.findByTestId('save_playbook', {timeout: 30000}).should('not.be.disabled').click();
     cy.wait(2000);
-    cy.findByTestId('save_playbook', {timeout: TIMEOUTS.LARGE}).should('not.be.disabled').click();
+    cy.findByTestId('save_playbook', {timeout: 30000}).should('not.be.disabled').click();
 });
 
 // Select the playbook from the dropdown menu

--- a/tests-e2e/cypress/support/ui_commands.js
+++ b/tests-e2e/cypress/support/ui_commands.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import * as TIMEOUTS from '../fixtures/timeouts';
-
 function waitUntilPermanentPost() {
     cy.get('#postListContent').should('exist');
     cy.waitUntil(() => cy.findAllByTestId('postView').last().then((el) => !(el[0].id.includes(':'))));
@@ -11,11 +9,11 @@ function waitUntilPermanentPost() {
 function clickPostHeaderItem(postId, location, item) {
     if (postId) {
         cy.get(`#post_${postId}`).trigger('mouseover', {force: true});
-        cy.wait(TIMEOUTS.TINY).get(`#${location}_${item}_${postId}`).click({force: true});
+        cy.wait(500).get(`#${location}_${item}_${postId}`).click({force: true});
     } else {
         cy.getLastPostId().then((lastPostId) => {
             cy.get(`#post_${lastPostId}`).trigger('mouseover', {force: true});
-            cy.wait(TIMEOUTS.TINY).get(`#${location}_${item}_${lastPostId}`).click({force: true});
+            cy.wait(500).get(`#${location}_${item}_${lastPostId}`).click({force: true});
         });
     }
 }
@@ -100,7 +98,7 @@ Cypress.Commands.add('getCurrentUserId', () => {
 
 // verifyPostedMessage verifies the receipt of a post containing the given message substring.
 Cypress.Commands.add('verifyPostedMessage', (message) => {
-    cy.wait(TIMEOUTS.TINY).getLastPostId().then((postId) => {
+    cy.wait(500).getLastPostId().then((postId) => {
         cy.get(`#post_${postId}`).within(() => {
             cy.get(`#postMessageText_${postId}`).contains(message);
         });
@@ -118,7 +116,7 @@ Cypress.Commands.add('verifyEphemeralMessage', (message, isCompactMode, needsToS
     }
 
     // # Checking if we got the ephemeral message with the selection we made
-    cy.wait(TIMEOUTS.TINY).getLastPostId().then((postId) => {
+    cy.wait(500).getLastPostId().then((postId) => {
         cy.get(`#post_${postId}`).within(() => {
             if (isCompactMode) {
                 // * Check if Bot message only visible to you and has requisite message.

--- a/webapp/src/components/backstage/backstage.tsx
+++ b/webapp/src/components/backstage/backstage.tsx
@@ -34,6 +34,7 @@ import CloudModal from 'src/components/cloud_modal';
 
 import StatsView from './stats';
 import SettingsView from './settings';
+import {BackstageNavbar, BackstageNavbarIcon} from './backstage_navbar';
 
 const BackstageContainer = styled.div`
     background: var(--center-channel-bg);
@@ -41,45 +42,6 @@ const BackstageContainer = styled.div`
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-`;
-
-export const BackstageNavbarIcon = styled.button`
-    border: none;
-    outline: none;
-    background: transparent;
-    border-radius: 4px;
-    font-size: 24px;
-    padding: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    color: var(--center-channel-color-56);
-
-    &:hover {
-        background: var(--button-bg-08);
-        text-decoration: unset;
-        color: var(--button-bg);
-    }
-`;
-
-export const BackstageNavbar = styled.div`
-    position: sticky;
-    width: 100%;
-    top: 0;
-    z-index: 2;
-
-    display: flex;
-    align-items: center;
-    padding: 28px 31px;
-    background: var(--center-channel-bg);
-    color: var(--center-channel-color);
-    font-family: 'compass-icons';
-    box-shadow: inset 0px -1px 0px var(--center-channel-color-16);
-
-    font-family: 'Open Sans';
-    font-style: normal;
-    font-weight: 600;
 `;
 
 const BackstageTitlebarItem = styled(NavLink)`

--- a/webapp/src/components/backstage/backstage_navbar.tsx
+++ b/webapp/src/components/backstage/backstage_navbar.tsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const BackstageNavbarIcon = styled.button`
+    border: none;
+    outline: none;
+    background: transparent;
+    border-radius: 4px;
+    font-size: 24px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: var(--center-channel-color-56);
+
+    &:hover {
+        background: var(--button-bg-08);
+        text-decoration: unset;
+        color: var(--button-bg);
+    }
+`;
+
+export const BackstageNavbar = styled.div`
+    position: sticky;
+    width: 100%;
+    top: 0;
+    z-index: 2;
+
+    display: flex;
+    align-items: center;
+    padding: 28px 31px;
+    background: var(--center-channel-bg);
+    color: var(--center-channel-color);
+    font-family: 'compass-icons';
+    box-shadow: inset 0px -1px 0px var(--center-channel-color-16);
+
+    font-family: 'Open Sans';
+    font-style: normal;
+    font-weight: 600;
+`;
+

--- a/webapp/src/components/backstage/playbook_edit.tsx
+++ b/webapp/src/components/backstage/playbook_edit.tsx
@@ -20,7 +20,7 @@ import {savePlaybook, clientFetchPlaybook} from 'src/client';
 import {StagesAndStepsEdit} from 'src/components/backstage/stages_and_steps_edit';
 import {ErrorPageTypes, TEMPLATE_TITLE_KEY, PROFILE_CHUNK_SIZE} from 'src/constants';
 import {PrimaryButton} from 'src/components/assets/buttons';
-import {BackstageNavbar} from 'src/components/backstage/backstage';
+import {BackstageNavbar} from 'src/components/backstage/backstage_navbar';
 import {AutomationSettings} from 'src/components/backstage/automation/settings';
 import RouteLeavingGuard from 'src/components/backstage/route_leaving_guard';
 import {SecondaryButtonSmaller} from 'src/components/backstage/playbook_runs/shared';
@@ -181,6 +181,10 @@ const retrospectiveReminderOptions = [
 
 // @ts-ignore
 const WebappUtils = window.WebappUtils;
+
+const PlaybookNavbar = styled(BackstageNavbar)`
+    top: 80px;
+`;
 
 const PlaybookEdit = (props: Props) => {
     const dispatch = useDispatch();
@@ -489,7 +493,7 @@ const PlaybookEdit = (props: Props) => {
 
     return (
         <OuterContainer>
-            <BackstageNavbar
+            <PlaybookNavbar
                 data-testid='backstage-nav-bar'
             >
                 <EditableTexts>
@@ -520,7 +524,7 @@ const PlaybookEdit = (props: Props) => {
                         {'Save'}
                     </span>
                 </PrimaryButton>
-            </BackstageNavbar>
+            </PlaybookNavbar>
             <Container>
                 <EditView>
                     <TabsHeader>


### PR DESCRIPTION
#### Summary
Make the playbook navbar sticky. It was technically already sticky, but had a `top: 0px` that prevented it from staying below the sticky header. This makes `Save` front and centre, instead of `X`; it also helps fix a few Cypress unit tests with the (yet to be merged) upgraded Cypress 7.

<img width="873" alt="image" src="https://user-images.githubusercontent.com/1023171/125837068-495f482a-98f4-41cd-9e55-13fc5a1d8532.png">

#### Ticket Link
None.

#### Checklist
- ~~[ ] Telemetry updated~~
- ~~[ ] Gated by experimental feature flag~~
- [ ] Unit tests updated
