### PR TITLE
properly initialize fixture users

### DIFF
--- a/tests-e2e/cypress/support/index.js
+++ b/tests-e2e/cypress/support/index.js
@@ -13,11 +13,13 @@ import './api/preference';
 import './api/user';
 import './test_commands';
 
+import fixtureUsers from '../fixtures/users';
+
 require('cypress-terminal-report/src/installLogsCollector')();
 
 before(() => {
     // Disable the tutorial, cloud onboarding, and whats new modal for specific users.
-    const userNames = ['sysadmin', 'user-1', 'user-2'];
+    const userNames = Object.values(fixtureUsers).map((user) => user.username);
 
     cy.apiAdminLogin().then(() => {
         cy.apiGetUsersByUsernames(userNames).then(({users}) => users.forEach((user) => {


### PR DESCRIPTION
#### Summary
`user-2` as a username doesn't actually exist -- its `samuel.tucker` in the test data -- and we weren't correctly initializing preferences for the welcome modal for this users, used in a few tests. I presume the failure itself was upstream from incoming changes around the welcome modal.

#### Ticket Link
None.

#### Checklist
- [ ] ~~Telemetry updated~~
- [ ] ~~Gated by experimental feature flag~~
- [x] Unit tests updated
